### PR TITLE
When QueueName is overriden using AzureQueueConfig, all messages will be sent to the originating endpoint instead of the specified destination

### DIFF
--- a/src/Transport/Config/AzureQueueConfig.cs
+++ b/src/Transport/Config/AzureQueueConfig.cs
@@ -2,9 +2,13 @@ namespace NServiceBus.Config
 {
     using System.Configuration;
     using Azure.Transports.WindowsAzureStorageQueues;
+    using NServiceBus.Logging;
 
     public class AzureQueueConfig : ConfigurationSection
     {
+        ILog logger = LogManager.GetLogger<AzureQueueConfig>();
+
+        [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", Replacement = "configuration.EndpointName(name)")]        
         [ConfigurationProperty("QueueName", IsRequired = false, DefaultValue = null)]
         public string QueueName
         {
@@ -14,6 +18,7 @@ namespace NServiceBus.Config
             }
             set
             {
+                logger.Warn("AzureQueueConfig.QueueName is deprecated and will be removed in version 8.0. Use `configuration.EndpointName(name)` instead to define endpoint and input queue names.");
                 this["QueueName"] = value;
             }
         }
@@ -96,6 +101,7 @@ namespace NServiceBus.Config
             }
         }
 
+        [ObsoleteEx(RemoveInVersion = "8", TreatAsErrorFromVersion = "7", Replacement = "configuration.ScaleOut().UniqueQueuePerEndpointInstance()")]        
         [ConfigurationProperty("QueuePerInstance", IsRequired = false, DefaultValue = AzureMessageQueueReceiver.DefaultQueuePerInstance)]
         public bool QueuePerInstance
         {
@@ -105,6 +111,7 @@ namespace NServiceBus.Config
             }
             set
             {
+                logger.Warn("AzureQueueConfig.QueuePerInstance is deprecated and will be removed in version 8.0. Use `configuration.ScaleOut().UniqueQueuePerEndpointInstance()` instead.");
                 this["QueuePerInstance"] = value;
             }
         }


### PR DESCRIPTION
## Who's affected

Anyone who's using Azure Storage Queues transport and overriding `QueueName` of endpoint using `AzureQueueConfig`

## Symptoms

Messages sent to destination endpoint(s) end up in the originating endpoint`s queue

## Repro code
```c#
    class EndpointConfig : IConfigureThisEndpoint, AsA_Worker
    {
        public void Customize(BusConfiguration configuration)
        {
            configuration.UseTransport<AzureStorageQueueTransport>();
            configuration.UsePersistence<InMemoryPersistence>();
        }

        class OverrideQueueNameForEndpoint : IProvideConfiguration<AzureStorageQueueTransport>
        {
            public AzureStorageQueueTransport GetConfiguration()
            {
                return new AzureStorageQueueTransport
                {
                    QueueName = "kaboomriko"
                };
            }
        }

        class Boostrapper : IWantToRunWhenBusStartsAndStops
        {
            public IBus Bus { get; set; }

            public void Start()
            {
                Bus.Send("particular.servicecontrol.dev", new DoSomething());
            }

            public void Stop()
            {
            }
        }

        public class DoSomething : ICommand
        {
        }

        class ErrorQueueConfiguration : IProvideConfiguration<MessageForwardingInCaseOfFaultConfig>
        {
            public MessageForwardingInCaseOfFaultConfig GetConfiguration()
            {
                return new MessageForwardingInCaseOfFaultConfig {ErrorQueue = "error"};
            }
        }
    }
```

**Proper Code / Workaround**

```c#
    class EndpointConfig : IConfigureThisEndpoint, AsA_Worker
    {
        public void Customize(BusConfiguration configuration)
        {
            configuration.UseTransport<AzureStorageQueueTransport>();
            configuration.UsePersistence<InMemoryPersistence>();

            configuration.EndpointName("kaboomriko");  // fix
        }

        class Boostrapper : IWantToRunWhenBusStartsAndStops
        {
            public IBus Bus { get; set; }

            public void Start()
            {
                Bus.Send("particular.servicecontrol.dev", new DoSomething());
            }

            public void Stop()
            {
            }
        }

        public class DoSomething : ICommand
        {
        }

        class ErrorQueueConfiguration : IProvideConfiguration<MessageForwardingInCaseOfFaultConfig>
        {
            public MessageForwardingInCaseOfFaultConfig GetConfiguration()
            {
                return new MessageForwardingInCaseOfFaultConfig {ErrorQueue = "error"};
            }
        }
    }
```

## Things To Do
- [ ] Update [documentation](http://docs.particular.net/nservicebus/azure/azure-storage-queues-transport#detailed-configuration)
- [x] Log warning for settings such as `QueueName`, `QueuePerInstance` 

**Original issue** reported in Desk [case 9292](https://nservicebus.desk.com/agent/case/9292)