### PR TITLE
Stopping gracefully the endpoint

### DIFF
--- a/src/Transport/MessagePump.cs
+++ b/src/Transport/MessagePump.cs
@@ -148,6 +148,10 @@
                     await circuitBreaker.Failure(ex).ConfigureAwait(false);
                     continue;
                 }
+                catch (TaskCanceledException)
+                {
+                    return;
+                }
                 catch (Exception ex)
                 {
                     Logger.Warn("Receiving from the queue failed", ex);


### PR DESCRIPTION
Making sure that when stopping the endpoint no exception related to that is put into logs.
Fix #65