### PR TITLE
MessagePump and Message Ack changes

### DIFF
--- a/src/Transport/AzureMessageQueueReceiver.cs
+++ b/src/Transport/AzureMessageQueueReceiver.cs
@@ -56,11 +56,27 @@ namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues
             }
         }
 
-        internal async Task<MessageRetrieved> Receive(CancellationToken token)
+        internal async Task<IEnumerable<MessageRetrieved>> Receive(CancellationToken token)
         {
-            var rawMessage = await GetMessage(token).ConfigureAwait(false);
+            var rawMessages = await azureQueue.GetMessagesAsync(BatchSize, TimeSpan.FromMilliseconds(MessageInvisibleTime), null, null, token).ConfigureAwait(false);
 
-            if (rawMessage == null)
+            bool messageFound = false;
+            var messages = new List<MessageRetrieved>();
+            foreach (var rawMessage in rawMessages)
+            {
+                messageFound = true;
+                try
+                {
+                    var wrapper = DeserializeMessage(rawMessage);
+                    messages.Add(new MessageRetrieved(wrapper, rawMessage, azureQueue, true));
+                }
+                catch (Exception ex)
+                {
+                    throw new EnvelopeDeserializationFailed(rawMessage, ex);
+                }
+            }
+
+            if (!messageFound)
             {
                 if (timeToDelayNextPeek + PeekInterval < MaximumWaitTimeWhenIdle)
                 {
@@ -69,37 +85,10 @@ namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues
                 else timeToDelayNextPeek = MaximumWaitTimeWhenIdle;
 
                 await Task.Delay(timeToDelayNextPeek, token).ConfigureAwait(false);
-                return null;
             }
 
             timeToDelayNextPeek = 0;
-            try
-            {
-                var wrapper = DeserializeMessage(rawMessage);
-                return new MessageRetrieved(wrapper, rawMessage, azureQueue, true);
-            }
-            catch (Exception ex)
-            {
-                throw new EnvelopeDeserializationFailed(rawMessage, ex);
-            }
-        }
-
-        async Task<CloudQueueMessage> GetMessage(CancellationToken token)
-        {
-            if (batchQueue.Count == 0)
-            {
-                var messages = await azureQueue.GetMessagesAsync(BatchSize, TimeSpan.FromMilliseconds(MessageInvisibleTime), null, null, token).ConfigureAwait(false);
-                foreach (var receivedMessage in messages)
-                {
-                    batchQueue.Enqueue(receivedMessage);
-                }
-            }
-            if (batchQueue.Count > 0)
-            {
-                return batchQueue.Dequeue();
-            }
-
-            return null;
+            return messages;
         }
 
         MessageWrapper DeserializeMessage(CloudQueueMessage rawMessage)

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -37,7 +37,8 @@
                 () =>
                 {
                     var addressing = GetAddressing(settings, connectionString);
-                    var receiver = new AzureMessageQueueReceiver(GetSerializer(settings), client, GetAddressGenerator(settings))
+                    var unwrapper = new MessageEnvelopeUnwrapper(GetSerializer(settings));
+                    var receiver = new AzureMessageQueueReceiver(unwrapper, client, GetAddressGenerator(settings))
                     {
                         PurgeOnStartup = settings.Get<bool>(WellKnownConfigurationKeys.PurgeOnStartup),
                         MaximumWaitTimeWhenIdle = settings.Get<int>(WellKnownConfigurationKeys.ReceiverMaximumWaitTimeWhenIdle),

--- a/src/Transport/MessageEnvelopeUnwrapper.cs
+++ b/src/Transport/MessageEnvelopeUnwrapper.cs
@@ -1,0 +1,52 @@
+namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues
+{
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization;
+    using Microsoft.WindowsAzure.Storage.Queue;
+
+    class MessageEnvelopeUnwrapper
+    {
+        public MessageEnvelopeUnwrapper(MessageWrapperSerializer messageSerializer)
+        {
+            messageWrapperSerializer = messageSerializer;
+        }
+
+        public MessageWrapper Unwrap(CloudQueueMessage rawMessage)
+        {
+            MessageWrapper m;
+            using (var stream = new MemoryStream(rawMessage.AsBytes))
+            {
+                try
+                {
+                    m = messageWrapperSerializer.Deserialize(stream);
+                }
+                catch (Exception)
+                {
+                    throw new SerializationException("Failed to deserialize message with id: " + rawMessage.Id);
+                }
+            }
+
+            if (m == null)
+            {
+                throw new SerializationException("Failed to deserialize message with id: " + rawMessage.Id);
+            }
+
+            if (m.ReplyToAddress != null)
+            {
+                m.Headers[Headers.ReplyToAddress] = m.ReplyToAddress;
+            }
+            m.Headers[Headers.CorrelationId] = m.CorrelationId;
+
+            if (m.TimeToBeReceived != TimeSpan.MaxValue)
+            {
+                m.Headers[Headers.TimeToBeReceived] = m.TimeToBeReceived.ToString();
+            }
+            m.Headers[Headers.MessageIntent] = m.MessageIntent.ToString(); // message intent exztension method
+
+            return m;
+        }
+
+        MessageWrapperSerializer messageWrapperSerializer;
+    }
+}

--- a/src/Transport/MessagePump.cs
+++ b/src/Transport/MessagePump.cs
@@ -14,6 +14,9 @@
 
     class MessagePump : IPushMessages, IDisposable
     {
+        AzureStorageAddressingSettings addressing;
+
+        AzureMessageQueueReceiver messageReceiver;
         public MessagePump(AzureMessageQueueReceiver messageReceiver, AzureStorageAddressingSettings addressing)
         {
             this.messageReceiver = messageReceiver;
@@ -104,18 +107,36 @@
         {
             while (!cancellationTokenSource.IsCancellationRequested)
             {
-                MessageRetrieved retrieved;
                 try
                 {
-                    retrieved = await messageReceiver.Receive(cancellationTokenSource.Token).ConfigureAwait(false);
-                    if (retrieved == null)
-                    {
-                        continue;
-                    }
+                    var retrieved = await messageReceiver.Receive(cancellationTokenSource.Token).ConfigureAwait(false);
 
-                    if (ackBeforeDispatch)
+                    foreach (var message in retrieved)
                     {
-                        await retrieved.Ack().ConfigureAwait(false);
+                        await concurrencyLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                        if (cancellationTokenSource.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
+                        var receiveTask = InnerReceive(message);
+
+                        runningReceiveTasks.TryAdd(receiveTask, receiveTask);
+
+                        // We insert the original task into the runningReceiveTasks because we want to await the completion
+                        // of the running receives. ExecuteSynchronously is a request to execute the continuation as part of
+                        // the transition of the antecedents completion phase. This means in most of the cases the continuation
+                        // will be executed during this transition and the antecedent task goes into the completion state only
+                        // after the continuation is executed. This is not always the case. When the TPL thread handling the
+                        // antecedent task is aborted the continuation will be scheduled. But in this case we don't need to await
+                        // the continuation to complete because only really care about the receive operations. The final operation
+                        // when shutting down is a clear of the running tasks anyway.
+                        receiveTask.ContinueWith(t =>
+                        {
+                            Task toBeRemoved;
+                            runningReceiveTasks.TryRemove(t, out toBeRemoved);
+                        }, TaskContinuationOptions.ExecuteSynchronously).Ignore();
                     }
 
                     circuitBreaker.Success();
@@ -124,15 +145,13 @@
                 {
                     Logger.Error($"The queue '{ex.Queue}' was not found. Create the queue.", ex);
                     await circuitBreaker.Failure(ex).ConfigureAwait(false);
-                    continue;
                 }
                 catch (UnableToDispatchException ex)
                 {
                     Logger.Error($"The dispach failed at sending a message to the following queue: '{ex.Queue}'", ex);
                     await circuitBreaker.Failure(ex).ConfigureAwait(false);
-                    continue;
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
                     return;
                 }
@@ -140,66 +159,49 @@
                 {
                     Logger.Warn("Receiving from the queue failed", ex);
                     await circuitBreaker.Failure(ex).ConfigureAwait(false);
-                    continue;
                 }
+            }
+        }
 
-                if (cancellationTokenSource.IsCancellationRequested)
+        private async Task InnerReceive(MessageRetrieved retrieved)
+        {
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                try
                 {
-                    return;
-                }
-
-                await concurrencyLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-                var tokenSource = new CancellationTokenSource();
-                var receiveTask = Task.Run(async () =>
-                {
-                    try
+                    if (ackBeforeDispatch)
                     {
-                        var message = retrieved.Wrapper;
+                        await retrieved.Ack().ConfigureAwait(false);
+                    }
 
-                        addressing.ApplyMappingToLogicalName(message.Headers);
+                    var message = retrieved.Wrapper;
 
-                        var pushContext = new PushContext(message.Id, message.Headers, new MemoryStream(message.Body), new TransportTransaction(), tokenSource, new ContextBag());
-                        await pipeline(pushContext).ConfigureAwait(false);
+                    addressing.ApplyMappingToLogicalName(message.Headers);
 
-                        if (ackBeforeDispatch == false)
+                    var pushContext = new PushContext(message.Id, message.Headers, new MemoryStream(message.Body), new TransportTransaction(), tokenSource, new ContextBag());
+                    await pipeline(pushContext).ConfigureAwait(false);
+
+                    if (ackBeforeDispatch == false)
+                    {
+                        if (tokenSource.IsCancellationRequested == false)
                         {
-                            if (tokenSource.IsCancellationRequested == false)
-                            {
-                                await retrieved.Ack().ConfigureAwait(false);
-                            }
-                            else
-                            {
-                                await retrieved.Nack().ConfigureAwait(false);
-                            }
+                            await retrieved.Ack().ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await retrieved.Nack().ConfigureAwait(false);
                         }
                     }
-                    catch (Exception ex)
-                    {
-                        await retrieved.Nack().ConfigureAwait(false);
-                        Logger.Warn("Azure Storage Queue transport failed pushing a message through pipeline", ex);
-                    }
-                    finally
-                    {
-                        concurrencyLimiter.Release();
-                    }
-                }, tokenSource.Token).ContinueWith(t => tokenSource.Dispose());
-
-                runningReceiveTasks.TryAdd(receiveTask, receiveTask);
-
-                // We insert the original task into the runningReceiveTasks because we want to await the completion
-                // of the running receives. ExecuteSynchronously is a request to execute the continuation as part of
-                // the transition of the antecedents completion phase. This means in most of the cases the continuation
-                // will be executed during this transition and the antecedent task goes into the completion state only
-                // after the continuation is executed. This is not always the case. When the TPL thread handling the
-                // antecedent task is aborted the continuation will be scheduled. But in this case we don't need to await
-                // the continuation to complete because only really care about the receive operations. The final operation
-                // when shutting down is a clear of the running tasks anyway.
-                receiveTask.ContinueWith(t =>
+                }
+                catch (Exception ex)
                 {
-                    Task toBeRemoved;
-                    runningReceiveTasks.TryRemove(t, out toBeRemoved);
-                }, TaskContinuationOptions.ExecuteSynchronously).Ignore();
+                    await retrieved.Nack().ConfigureAwait(false);
+                    Logger.Warn("Azure Storage Queue transport failed pushing a message through pipeline", ex);
+                }
+                finally
+                {
+                    concurrencyLimiter.Release();
+                }
             }
         }
 

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -7,15 +7,29 @@
 
     class MessageRetrieved
     {
-        public MessageRetrieved(MessageWrapper wrapper, CloudQueueMessage rawMessage, CloudQueue azureQueue, bool handleAckNack)
+        public MessageRetrieved(MessageEnvelopeUnwrapper unpacker, CloudQueueMessage rawMessage, CloudQueue azureQueue, bool handleAckNack = true)
         {
-            Wrapper = wrapper;
+            this.unpacker = unpacker;
             this.rawMessage = rawMessage;
             this.azureQueue = azureQueue;
             this.handleAckNack = handleAckNack;
         }
 
-        public MessageWrapper Wrapper { get; }
+        /// <summary>
+        /// Unwraps the raw message.
+        /// </summary>
+        /// <returns>Returns the message wrapper.</returns>
+        public MessageWrapper Unwrap()
+        {
+            try
+            {
+                return unpacker.Unwrap(rawMessage);
+            }
+            catch (Exception ex)
+            {
+                throw new EnvelopeDeserializationFailed(rawMessage, ex);
+            }
+        }
 
         /// <summary>
         /// Acknowledes the successful processing of the message.
@@ -65,6 +79,8 @@
                 }
             }
         }
+
+        MessageEnvelopeUnwrapper unpacker;
 
         CloudQueue azureQueue;
         bool handleAckNack;

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -103,6 +103,7 @@
     <Compile Include="AzureMessageQueueCreator.cs" />
     <Compile Include="AzureStorageQueueInfrastructure.cs" />
     <Compile Include="Dispatcher.cs" />
+    <Compile Include="MessageEnvelopeUnwrapper.cs" />
     <Compile Include="MessagePump.cs" />
     <Compile Include="RepeatedFailuresOverTimeCircuitBreaker.cs" />
     <Compile Include="AzureMessageQueueReceiver.cs" />


### PR DESCRIPTION
Connects to #67

* MessagePump no longer uses Task.Run for async receive and no longer schedules a task for tokenSource.Dispose
* Ack of messages happens concurrently in the inner receive and only if there are slot on the semaphore available
* Unpacking the message envelop concurrently in the inner receive