### PR TITLE
Message pump parallel

### DIFF
--- a/src/Tests/API/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
@@ -51,6 +51,7 @@ namespace NServiceBus
     {
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> BatchSize(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, int value) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> ConnectionString(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, string value) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> DegreeOfReceiveParallelism(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, int degreeOfReceiveParallelism) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> MaximumWaitTimeWhenIdle(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, int value) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> MessageInvisibleTime(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, int value) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> MessageInvisibleTime(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, System.TimeSpan value) { }

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -47,7 +47,13 @@
                         BatchSize = settings.Get<int>(WellKnownConfigurationKeys.ReceiverBatchSize)
                     };
 
-                    return new MessagePump(receiver, addressing);
+                    int? degreeOfReceiveParallelism = null;
+                    int parallelism;
+                    if (settings.TryGet(WellKnownConfigurationKeys.DegreeOfReceiveParallelism, out parallelism))
+                    {
+                        degreeOfReceiveParallelism = parallelism;
+                    }
+                    return new MessagePump(receiver, addressing, degreeOfReceiveParallelism);
                 },
                 () => new AzureMessageQueueCreator(client, GetAddressGenerator(settings)),
                 () => Task.FromResult(StartupCheckResult.Success)

--- a/src/Transport/Config/AzureStorageTransportExtensions.cs
+++ b/src/Transport/Config/AzureStorageTransportExtensions.cs
@@ -100,5 +100,21 @@ namespace NServiceBus
             config.GetSettings().Set(WellKnownConfigurationKeys.Sha1Shortener, true);
             return config;
         }
+
+        /// <summary>
+        /// Sets the degree of parallelism that should be used to receive messages.
+        /// </summary>
+        public static TransportExtensions<AzureStorageQueueTransport> DegreeOfReceiveParallelism(this TransportExtensions<AzureStorageQueueTransport> config, int degreeOfReceiveParallelism)
+        {
+            if (degreeOfReceiveParallelism < 1 || degreeOfReceiveParallelism > MaxDegreeOfReceiveParallelism)
+            {
+                throw new ArgumentOutOfRangeException(nameof(degreeOfReceiveParallelism), degreeOfReceiveParallelism, "DegreeOfParallelism must be between 1 and 32.");
+            }
+
+            config.GetSettings().Set(WellKnownConfigurationKeys.DegreeOfReceiveParallelism, degreeOfReceiveParallelism);
+            return config;
+        }
+
+        internal const int MaxDegreeOfReceiveParallelism = 32;
     }
 }

--- a/src/Transport/Config/DefaultConfigurationValues.cs
+++ b/src/Transport/Config/DefaultConfigurationValues.cs
@@ -24,7 +24,7 @@
         const int DefaultMessageInvisibleTime = 30000;
         const int DefaultPeekInterval = 50;
         const int DefaultMaximumWaitTimeWhenIdle = 1000;
-        const int DefaultBatchSize = 10;
+        const int DefaultBatchSize = 32;
         const bool DefaultPurgeOnStartup = false;
         const string DefaultConnectionString = "";
         const bool DefaultQueuePerInstance = false;

--- a/src/Transport/Config/WellKnownConfigurationKeys.cs
+++ b/src/Transport/Config/WellKnownConfigurationKeys.cs
@@ -11,5 +11,6 @@
         public const string Sha1Shortener = "Transport.AzureStorageQueue.Sha1Shortener";
         public const string PurgeOnStartup = "Transport.AzureStorageQueue.PurgeOnStartup";
         public const string DefaultQueuePerInstance = "Transport.AzureStorageQueue.DefaultQueuePerInstance";
+        public const string DegreeOfReceiveParallelism = "Transport.AzureStorageQueue.DegreeOfReceiveParallelism";
     }
 }


### PR DESCRIPTION
Connects to #67

## TLDR

* The factor that influences the receive speed the most is the pulling of messages from the queue.
* Introduced degree of parallelism (default `SquareRoot of MaxConcurrency but maximum 32`, let's call this dynamic degree of parallelism) which means that this version of the message pump will use by default a dynamic degree of parallel operations fetching messages from the queue defined by the default batch size. The concurrency settings of the core are not changed. It is perfectly valid to share the same semaphore which limits the number of messages.
* The maximum degree of parallelism is limited to a maximum of `32`. In my tests putting higher numbers hurts more than it helps.
* Switched the default batch size from `10 `to `32`. 
* Documentation PR: https://github.com/Particular/docs.particular.net/pull/1432

## Motivation of this change

In order to understand the motivation of this change it is necessary to compare version 6 to version 7.

### V6

The previous version of the message pump used background threads to pull messages from the queue defined by the default batch size. The pulled messages are added to a concurrent queue. After the pull the messages are fetched from the concurrent queue in parallel and the pipeline is dispatched. Setting the concurrency means that we allocate number of concurrency = number of threads. The more threads that are pulling from the queue the more contention will occur on the concurrent queue (in-memory). in summary:

* Messages are pulled from the queue in parallel defined by the concurrency setttings and added to an in-memory concurrent queue
* Dispatches to the pipeline are done on the receive thread by pulling out messages from the in-memory concurrent queue

### V7

The existing develop version uses one receive thread to pull messages from the queue defined by the default batch size. The pulled messages are concurrently deserialized, ACKed and the pipeline is dispatched (remark: depending on the `TransportTransactionMode` acking and dispatching actions can be swapped). In summary:

* Messages are pulled from the queue by one single polling thread
* Messages are handled concurrently (possibly on multiple threads)

## Limiting factor: Getting messages from the queue

Since the limiting factor is pulling messages from the queue we need to introduce parallelism to fetch messages in batches in parallel from the queue. Only with this approach we can improve the receive speed of the transport. 

## Design

Introduced a degree of receive parallelism setting which allows to specify the parallelism degree to get messages of the queue. The default batch size is increased to 32. By default the pump starts a a dynamically determined number of `ProcessMessages` operation on several `Task.Run`. Parallel receive loops will start polling messages from the queue. The semaphore is shared between those processing operations. Therefore the concurrency limitation still applies. When shutting down the message pump asynchronously awaits the completion of these receive loops.

Calculations:

Trademarked by @timbussmann 

Degree of parallelism = square root of MaxConcurrency (rounded)
(concurrency 1 = 1, concurrency 10 = 3, concurrency 20 = 4, concurrency 50 = 7, concurrency 100 [default] = 10, concurrency 200 = 14, concurrency 1000 = 32)

## Benefits over version 6

Version 6 cannot keep up with version 7 of the message pump. The contention on the concurrent queue becomes too high and slows the whole process down. The blocking version is more wasteful in terms of using threads and ultimately takes longer.

## Results

> Receiving #1000 of msgs over the bus took 0:00:00:00.6502887

Another run

> Receiving #1000 of msgs over the bus took 0:00:00:00.5414934

The top I saw on my machine was around 500 ms for 1000 messages. With a batch size of 32 and a degree of parallelism of 32 and concurrency set to 1000. The results really vary and the problem is that you need to make sure that you choose values so that you do not reach the IOP limits, if you do azure storage will slow you down by applying back pressure.

With version 6 and concurrency set to 200 (means 200 Threads!) and batch size set to 32. I was able to consume 1000 messages in 2000-3000 ms. 

That makes this version 7 of the transport 4-6 times faster.