### PR TITLE
Refactor Dispatcher to send messages concurrently

### DIFF
--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -31,7 +31,7 @@
         public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()
         {
             var connectionObject = new ConnectionString(connectionString);
-            var client = new CreateQueueClients().CreateReceiver(connectionObject);
+            var client = CreateQueueClients.CreateReceiver(connectionObject);
 
             return new TransportReceiveInfrastructure(
                 () =>

--- a/src/Transport/CreateQueueClients.cs
+++ b/src/Transport/CreateQueueClients.cs
@@ -11,12 +11,12 @@ namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues
             return destinationQueueClients.GetOrAdd(connectionString, BuildClient);
         }
 
-        public CloudQueueClient CreateReceiver(ConnectionString connectionString)
+        public static CloudQueueClient CreateReceiver(ConnectionString connectionString)
         {
             return BuildClient(connectionString);
         }
 
-        CloudQueueClient BuildClient(ConnectionString connectionString)
+        static CloudQueueClient BuildClient(ConnectionString connectionString)
         {
             CloudStorageAccount account;
             if (CloudStorageAccount.TryParse(connectionString.Value, out account))


### PR DESCRIPTION
changing Dispatcher to execute sends concurrently instead of dispatching them sequentially. This results in batched sends being faster due to better usage of parallel http requests.

Tests showed that the `WhenAll` is can be up to 3x faster than the sequential code. Note that this heavily depends on the `ServicePointManager.DefaultConnectionLimit`. The sequential approach has the side-effect of easier request reuse compared to concurrent requests which have to open new connections when the connection limit is too high.

Also switched to using `ExistsAsync`. Async all the way.

I think there are valid reasons for both the previous approach (foreach-await) and the suggested code (WhenAll). The later should outperform the first when sending multiple messages from a handler. It's hard to name a threshold when a concurrent dispatch (to azure) is faster than the sequential approach since it also heavily depends whether it has to open a new connection or reuse an existing one. Another good point came from @Scooletz: When hitting request limitations the sequential approach has to handle less 50X reponses and retries than when sending messages concurrently. Similar is for Queue existence checks: when multiple messages go to the same non-existent queue, callers will receive an `AggregateException` containing exceptions for each message in the batch compared to a single one.

@Particular/azure-storage-queues-maintainers please review.