### PR TITLE
Ensure backward compatibility

### DIFF
--- a/src/Transport/MessagePump.cs
+++ b/src/Transport/MessagePump.cs
@@ -176,7 +176,8 @@
                     var message = retrieved.Unwrap();
                     addressing.ApplyMappingToLogicalName(message.Headers);
 
-                    using (var memoryStream = new MemoryStream(message.Body))
+                    var body = message.Body ?? new byte[0];
+                    using (var memoryStream = new MemoryStream(body))
                     {
                         var pushContext = new PushContext(message.Id, message.Headers, memoryStream, new TransportTransaction(), tokenSource, new ContextBag());
                         await pipeline(pushContext).ConfigureAwait(false);


### PR DESCRIPTION
Connects to #86 

The issue happens when v6 core (v7 transport) is the publisher and v5 core (v6 transport) is the subscriber: subscrber sends a message to publisher to register subscription needs.
In this context, message body is `null`, but v7 transport throws because it tries to push back to core a `MemoryStream` with `null` content

@Particular/azure-storage-queues-maintainers ping!