### PR TITLE
Change location of binaries folder

### DIFF
--- a/packaging/nuget/nservicebus.azurestoragequeues.nuspec
+++ b/packaging/nuget/nservicebus.azurestoragequeues.nuspec
@@ -19,6 +19,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\src\binaries\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.???" target="lib\net452" />
+    <file src="..\..\binaries\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.???" target="lib\net452" />
   </files>
 </package>

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -24,11 +24,11 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\binaries\</OutputPath>
+    <OutputPath>..\..\binaries\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>..\binaries\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.xml</DocumentationFile>
+    <DocumentationFile>..\..\binaries\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.xml</DocumentationFile>
     <NoWarn>1591, 0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
@@ -36,11 +36,11 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\binaries\</OutputPath>
+    <OutputPath>..\..\binaries\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>..\binaries\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.xml</DocumentationFile>
+    <DocumentationFile>..\..\binaries\NServiceBus.Azure.Transports.WindowsAzureStorageQueues.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#723

Moving binaries 1 level up in a hierachy
The reason for that is to allign with others repositories where binaries is on the same level as src folder
