### PR TITLE
Logical mapping of the default account fixed.

### DIFF
--- a/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
+++ b/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
@@ -27,7 +27,9 @@ public class ConfigureEndpointAzureStorageQueueTransport : IConfigureEndpointTes
         configuration.UseTransport<AzureStorageQueueTransport>()
             .ConnectionString(connectionString)
             .MessageInvisibleTime(TimeSpan.FromSeconds(5))
-            .SerializeMessageWrapperWith<JsonSerializer>();
+            .SerializeMessageWrapperWith<JsonSerializer>()
+            .Addressing()
+            .UseAccountNamesInsteadOfConnectionStrings();
 
         CleanQueuesUsedByTest(connectionString);
 

--- a/src/Transport/Config/Extensions/AzureStorageAddressingSettings.cs
+++ b/src/Transport/Config/Extensions/AzureStorageAddressingSettings.cs
@@ -51,6 +51,12 @@
                     var address = QueueAddress.Parse(headerValue);
                     string name;
 
+                    // no mapping if address is default
+                    if (address.IsAccountDefault)
+                    {
+                        continue;
+                    }
+
                     // try map as connection string
                     if (TryMap(new ConnectionString(address.StorageAccount), out name))
                     {

--- a/src/Transport/Config/QueueAddress.cs
+++ b/src/Transport/Config/QueueAddress.cs
@@ -106,11 +106,13 @@
                 return (QueueName.GetHashCode()*397) ^ StorageAccount.GetHashCode();
             }
         }
-
+        
         public override string ToString()
         {
-            return $"{QueueName}@{StorageAccount}";
+            return IsAccountDefault ? QueueName : $"{QueueName}@{StorageAccount}";
         }
+
+        public bool IsAccountDefault => StorageAccount == DefaultStorageAccountName;
 
         public const string DefaultStorageAccountName = "";
         public const string Separator = "@";


### PR DESCRIPTION
The default account mapping was failing if logical-connection_string mapping was enabled. This fixes it.