### PR TITLE
An empty lambda is allowed for secure sends in one account

### DIFF
--- a/src/AcceptanceTests/Configuration/Should_accept_no_mappings_at_all.cs
+++ b/src/AcceptanceTests/Configuration/Should_accept_no_mappings_at_all.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.AcceptanceTests.WindowsAzureStorageQueues.Configuration
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Support;
+    using Azure.Transports.WindowsAzureStorageQueues.AcceptanceTests;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+    
+    public class When_configuring_account_names : NServiceBusAcceptanceTest
+    {
+        const string Default = "default";
+        const string Another = "another";
+
+        readonly string connectionString;
+        readonly string anotherConnectionString;
+
+        public When_configuring_account_names()
+        {
+            connectionString = Utils.GetEnvConfiguredConnectionString();
+            anotherConnectionString = Utils.BuildAnotherConnectionString(connectionString);
+        }
+
+        [Test]
+        public async void Should_accept_no_mappings_at_all()
+        {
+            await Configure(_ => { }).ConfigureAwait(false);
+        }
+
+        [Test]
+        public void Should_not_accept_mappings_without_default()
+        {
+            var ex = Assert.Throws<AggregateException>(async () => { await Configure(m => { m.MapAccount(Another, anotherConnectionString); }).ConfigureAwait(false); });
+            var inner = ex.InnerExceptions.OfType<ScenarioException>().Single();
+            Assert.IsInstanceOf<ArgumentException>(inner.InnerException);
+        }
+
+        [Test]
+        public async void Should_accept_mappings_with_default()
+        {
+            await Configure(m =>
+            {
+                m.MapLocalAccount(Default);
+                m.MapAccount(Another, anotherConnectionString);
+            }).ConfigureAwait(false);
+        }
+
+        Task Configure(Action<AccountMapping> action)
+        {
+            return Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(cfg => cfg.CustomConfig(c =>
+                  {
+                      c.UseTransport<NServiceBus.AzureStorageQueueTransport>()
+                          .UseAccountNamesInsteadOfConnectionStrings(action)
+                          .ConnectionString(connectionString)
+                          .SerializeMessageWrapperWith<JsonSerializer>();
+
+                  }))
+                .Done(c => c.WasStarted)
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasStarted { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => { c.EnableFeature<Bootstrapper>(); }).SendOnly();
+            }
+
+            public class Bootstrapper : Feature
+            {
+                public Bootstrapper()
+                {
+                    EnableByDefault();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    context.RegisterStartupTask(b => new MyTask(b.Build<Context>()));
+                }
+
+                public class MyTask : FeatureStartupTask
+                {
+                    public MyTask(Context scenarioContext)
+                    {
+                        this.scenarioContext = scenarioContext;
+                    }
+
+                    protected override Task OnStart(IMessageSession session)
+                    {
+                        scenarioContext.WasStarted = true;
+                        return Task.FromResult(0);
+                    }
+
+                    protected override Task OnStop(IMessageSession session)
+                    {
+                        return Task.FromResult(0);
+                    }
+
+                    readonly Context scenarioContext;
+                }
+            }
+        }
+    }
+}

--- a/src/AcceptanceTests/Configuration/When_mapping_account_names.cs
+++ b/src/AcceptanceTests/Configuration/When_mapping_account_names.cs
@@ -1,11 +1,11 @@
 ﻿namespace NServiceBus.AcceptanceTests.WindowsAzureStorageQueues.Configuration
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using Azure.Transports.WindowsAzureStorageQueues.AcceptanceTests;
     using EndpointTemplates;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Queue;
@@ -26,8 +26,8 @@
 
         public When_mapping_account_names()
         {
-            defaultConnectionString = Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString");
-            anotherConnectionString = defaultConnectionString + ";BlobEndpoint=https://notusedatall.blob.core.windows.net";
+            defaultConnectionString = Utils.GetEnvConfiguredConnectionString();
+            anotherConnectionString = Utils.BuildAnotherConnectionString(defaultConnectionString);
 
             var account = CloudStorageAccount.Parse(defaultConnectionString);
             auditQueue = account.CreateCloudQueueClient().GetQueueReference(AuditName);

--- a/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
+++ b/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
@@ -25,7 +25,6 @@ public class ConfigureEndpointAzureStorageQueueTransport : IConfigureEndpointTes
     {
         var connectionString = settings.Get<string>("Transport.ConnectionString");
         configuration.UseTransport<AzureStorageQueueTransport>()
-            .UseAccountNamesInsteadOfConnectionStrings(_ => { })
             .ConnectionString(connectionString)
             .MessageInvisibleTime(TimeSpan.FromSeconds(5))
             .SerializeMessageWrapperWith<JsonSerializer>();

--- a/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
+++ b/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
@@ -25,6 +25,7 @@ public class ConfigureEndpointAzureStorageQueueTransport : IConfigureEndpointTes
     {
         var connectionString = settings.Get<string>("Transport.ConnectionString");
         configuration.UseTransport<AzureStorageQueueTransport>()
+            .UseAccountNamesInsteadOfConnectionStrings(_ => { })
             .ConnectionString(connectionString)
             .MessageInvisibleTime(TimeSpan.FromSeconds(5))
             .SerializeMessageWrapperWith<JsonSerializer>();

--- a/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
@@ -300,11 +300,13 @@
     <Compile Include="Configuration\JsonExtensions.cs" />
     <Compile Include="Configuration\When_configuring_message_wrapper_serializer.cs" />
     <Compile Include="Configuration\When_mapping_account_names.cs" />
+    <Compile Include="Configuration\Should_accept_no_mappings_at_all.cs" />
     <Compile Include="ConfigureAzureStorageQueueTransport.cs" />
     <Compile Include="NamespaceSetup.cs" />
     <Compile Include="Sending\When_dispatching_fails.cs" />
     <Compile Include="Sending\When_dispatching_to_other_account.cs" />
     <Compile Include="Sending\When_message_is_sent_with_time_to_be_received_set_to_more_than_7_days.cs" />
+    <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Packages\NServiceBus.AcceptanceTests.5.0.0\**\*.cs" />

--- a/src/AcceptanceTests/Utils.cs
+++ b/src/AcceptanceTests/Utils.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues.AcceptanceTests
+{
+    using System;
+
+    public static class Utils
+    {
+        public static string GetEnvConfiguredConnectionString()
+        {
+            return Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString");
+        }
+
+        public static string BuildAnotherConnectionString(string connectionString)
+        {
+            return connectionString + ";BlobEndpoint=https://notusedatall.blob.core.windows.net";
+        }
+    }
+}

--- a/src/Tests/API/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
+++ b/src/Tests/API/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
@@ -16,6 +16,7 @@
     }
     public class static AzureStorageTransportAddressingExtensions
     {
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseAccountNamesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseAccountNamesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, System.Action<NServiceBus.AccountMapping> map) { }
     }
     public class static AzureStorageTransportExtensions

--- a/src/Transport/Config/Extensions/AzureStorageAddressingSettings.cs
+++ b/src/Transport/Config/Extensions/AzureStorageAddressingSettings.cs
@@ -9,6 +9,12 @@
     {
         public void UseAccountNamesInsteadOfConnectionStrings(string defaultConnectionStringName, Dictionary<string, string> name2connectionString = null)
         {
+            var hasAnyMapping = name2connectionString!= null && name2connectionString.Count > 0;
+            if (hasAnyMapping == false)
+            {
+                return;
+            }
+
             if (string.IsNullOrWhiteSpace(defaultConnectionStringName))
             {
                 throw new ArgumentException(nameof(defaultConnectionStringName));
@@ -17,20 +23,17 @@
             this.defaultConnectionStringName = defaultConnectionStringName;
             useLogicalQueueAddresses = true;
 
-            if (name2connectionString != null)
+            foreach (var kvp in name2connectionString)
             {
-                foreach (var kvp in name2connectionString)
+                var name = kvp.Key;
+                var connectionString = kvp.Value;
+
+                if (name == QueueAddress.DefaultStorageAccountName)
                 {
-                    var name = kvp.Key;
-                    var connectionString = kvp.Value;
-
-                    if (name == QueueAddress.DefaultStorageAccountName)
-                    {
-                        throw new ArgumentException("Don't use default empty name for mapping connection strings", nameof(name2connectionString));
-                    }
-
-                    Add(name, connectionString);
+                    throw new ArgumentException("Don't use default empty name for mapping connection strings", nameof(name2connectionString));
                 }
+
+                Add(name, connectionString);
             }
         }
 

--- a/src/Transport/Config/Extensions/AzureStorageTransportAddressingExtensions.cs
+++ b/src/Transport/Config/Extensions/AzureStorageTransportAddressingExtensions.cs
@@ -6,6 +6,11 @@ namespace NServiceBus
 
     public static class AzureStorageTransportAddressingExtensions
     {
+        public static TransportExtensions<AzureStorageQueueTransport> UseAccountNamesInsteadOfConnectionStrings(this TransportExtensions<AzureStorageQueueTransport> config)
+        {
+            return config.UseAccountNamesInsteadOfConnectionStrings(_ => { });
+        }
+
         public static TransportExtensions<AzureStorageQueueTransport> UseAccountNamesInsteadOfConnectionStrings(this TransportExtensions<AzureStorageQueueTransport> config,
             Action<AccountMapping> map)
         {


### PR DESCRIPTION
After changing the API, passing the name for the default account is no longer required from the API point of view. Unfortunately it breaks UX when using one account as it requires to call the mapping method for no reason. This PR fixes this behavior allowing to skip the mapping when using only one account.
Tests have been provided. 