### PR TITLE
Register message wrapper as system message

### DIFF
--- a/src/Transport/AzureStorageQueueTransport.cs
+++ b/src/Transport/AzureStorageQueueTransport.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using Azure.Transports.WindowsAzureStorageQueues;
     using AzureStorageQueues;
     using Serialization;
     using Settings;
@@ -19,6 +20,9 @@ namespace NServiceBus
         {
             // configure JSON instead of XML as the default serializer:
             settings.SetDefault<SerializationDefinition>(new JsonSerializer());
+
+            // register the MessageWrapper as a system message to have it registered in mappings and serializers
+            settings.Get<Conventions>().AddSystemMessagesConventions(t => t == typeof(MessageWrapper));
 
             new DefaultConfigurationValues().Apply(settings);
 


### PR DESCRIPTION
should fix https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/124

tested locally by removing `.SerializeMessageWrapperWith<JsonSerializer>();` from the transport config.

@Particular/azure-storage-queues-maintainers please review