### PR TITLE
Queue address generator

### DIFF
--- a/src/Transport/QueueAddressGenerator.cs
+++ b/src/Transport/QueueAddressGenerator.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AzureStorageQueues
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Text.RegularExpressions;
     using Config;
     using Settings;
@@ -21,16 +22,22 @@
 
         public string GetQueueName(string address)
         {
-            var name = SanitizeQueueName(address.ToLowerInvariant());
-            var input = address.Replace('.', '-').ToLowerInvariant(); // this string was used in the past to calculate guid, should stay backward compat
+            var queueName = address.ToLowerInvariant();
 
-            if (name.Length > 63)
+            return sanitizedQueueNames.GetOrAdd(queueName, name => ShortenQueueNameIfNecessary(name, SanitizeQueueName(name)));
+        }
+
+        string ShortenQueueNameIfNecessary(string address, string queueName)
+        {
+            if (queueName.Length <= 63)
             {
-                var shortenedName = shortener(input);
-                name = name.Substring(0, 63 - shortenedName.Length - 1).Trim('-') + "-" + shortenedName;
+                return queueName;
             }
 
-            return name;
+            var input = address.Replace('.', '-').ToLowerInvariant(); // this string was used in the past to calculate guid, should stay backward compat
+            var shortenedName = shortener(input);
+            queueName = $"{queueName.Substring(0, 63 - shortenedName.Length - 1).Trim('-')}-{shortenedName}";
+            return queueName;
         }
 
         static string SanitizeQueueName(string queueName)
@@ -42,6 +49,7 @@
         }
 
         Func<string, string> shortener;
+        ConcurrentDictionary<string, string> sanitizedQueueNames = new ConcurrentDictionary<string, string>();
 
         static Regex invalidCharacters = new Regex(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
         static Regex multipleDashes = new Regex(@"\-+", RegexOptions.Compiled);

--- a/src/Transport/QueueAddressGenerator.cs
+++ b/src/Transport/QueueAddressGenerator.cs
@@ -36,13 +36,14 @@
         static string SanitizeQueueName(string queueName)
         {
             //rules for naming queues can be found at http://msdn.microsoft.com/en-us/library/windowsazure/dd179349.aspx"
-            var invalidCharacters = new Regex(@"[^a-zA-Z0-9\-]");
             var sanitized = invalidCharacters.Replace(queueName, "-"); // this can lead to multiple - occurrences in a row
-            var multipleDashes = new Regex(@"\-+");
             sanitized = multipleDashes.Replace(sanitized, "-");
             return sanitized;
         }
 
         Func<string, string> shortener;
+
+        static Regex invalidCharacters = new Regex(@"[^a-zA-Z0-9\-]", RegexOptions.Compiled);
+        static Regex multipleDashes = new Regex(@"\-+", RegexOptions.Compiled);
     }
 }


### PR DESCRIPTION
## Micro benchmark

```ini

BenchmarkDotNet=v0.9.7.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Xeon(R) CPU E5-2673 v3 2.40GHz, ProcessorCount=8
Frequency=10000000 ticks, Resolution=100.0000 ns, Timer=UNKNOWN
HostCLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
JitModules=clrjit-v4.6.1055.0

Type=ASQQeueNameGenerator  Mode=Throughput  

```
              Method | Calls |        Median |        StdDev | Scaled |          Mean |    StdError |        StdDev |      Op/s |           Min |            Q1 |        Median |            Q3 |            Max |    Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
-------------------- |------ |-------------- |-------------- |------- |-------------- |------------ |-------------- |---------- |-------------- |-------------- |-------------- |-------------- |--------------- |--------- |------ |------ |------------------- |
 **BeforeOptimizations** |     **2** |    **16.2937 us** |     **0.8587 us** |   **1.00** |    **16.5858 us** |   **0.1831 us** |     **0.8587 us** |  **60292.41** |    **15.9275 us** |    **16.0710 us** |    **16.2937 us** |    **16.7249 us** |     **19.8277 us** |     **2.35** |     **-** |     **-** |          **10,796.61** |
       CompiledRegex |     2 |     2.7755 us |     0.3427 us |   0.17 |     2.9603 us |   0.0357 us |     0.3427 us | 337798.33 |     2.7131 us |     2.7428 us |     2.7755 us |     3.1307 us |      4.6658 us |     0.08 |     - |     - |             383.23 |
              Cached |     2 |     2.8667 us |     0.2459 us |   0.18 |     2.9977 us |   0.0298 us |     0.2459 us | 333589.33 |     2.7939 us |     2.8434 us |     2.8667 us |     3.1017 us |      3.8073 us |     0.23 |     - |     - |           1,103.28 |
 **BeforeOptimizations** |     **4** |    **32.1120 us** |     **1.8174 us** |   **1.00** |    **32.7983 us** |   **0.4064 us** |     **1.8174 us** |   **30489.4** |    **31.7279 us** |    **31.9235 us** |    **32.1120 us** |    **32.2436 us** |     **37.8283 us** |     **4.43** |     **-** |     **-** |          **20,312.14** |
       CompiledRegex |     4 |     5.5098 us |     0.5795 us |   0.17 |     5.8161 us |   0.0625 us |     0.5795 us | 171936.69 |     5.4102 us |     5.4674 us |     5.5098 us |     5.9326 us |      8.7637 us |     0.12 |     - |     - |             682.01 |
              Cached |     4 |     4.2710 us |     0.6373 us |   0.13 |     4.5397 us |   0.1425 us |     0.6373 us | 220281.15 |     4.1395 us |     4.1734 us |     4.2710 us |     4.4418 us |      6.3999 us |     0.29 |     - |     - |           1,372.53 |
 **BeforeOptimizations** |     **8** |    **64.6421 us** |     **6.7553 us** |   **1.00** |    **67.0744 us** |   **1.4086 us** |     **6.7553 us** |  **14908.83** |    **62.9471 us** |    **63.9339 us** |    **64.6421 us** |    **65.2869 us** |     **91.6027 us** |     **8.64** |     **-** |     **-** |          **39,553.78** |
       CompiledRegex |     8 |    11.0142 us |     1.2745 us |   0.17 |    11.6355 us |   0.1674 us |     1.2745 us |  85943.84 |    10.7556 us |    10.8778 us |    11.0142 us |    11.6618 us |     16.6771 us |     0.28 |     - |     - |           1,604.13 |
              Cached |     8 |     6.1121 us |     0.2350 us |   0.09 |     6.2005 us |   0.0526 us |     0.2350 us | 161277.11 |     5.9965 us |     6.0730 us |     6.1121 us |     6.2032 us |      6.8231 us |     0.36 |     - |     - |           1,782.56 |
 **BeforeOptimizations** |    **16** |   **136.1633 us** |     **9.3963 us** |   **1.00** |   **140.1491 us** |   **1.3423 us** |     **9.3963 us** |   **7135.26** |   **131.7644 us** |   **133.9978 us** |   **136.1633 us** |   **142.8035 us** |    **172.1387 us** |    **15.69** |     **-** |     **-** |          **72,248.39** |
       CompiledRegex |    16 |    22.7637 us |     1.2298 us |   0.17 |    23.1435 us |   0.2750 us |     1.2298 us |  43208.63 |    22.1809 us |    22.5491 us |    22.7637 us |    23.1587 us |     27.7564 us |     0.47 |     - |     - |           2,700.84 |
              Cached |    16 |     8.4165 us |     0.4410 us |   0.06 |     8.5848 us |   0.0725 us |     0.4410 us | 116484.81 |     8.0288 us |     8.2408 us |     8.4165 us |     8.7504 us |     10.0257 us |     0.39 |     - |     - |           1,918.80 |
 **BeforeOptimizations** |    **32** |   **283.9039 us** |    **22.9555 us** |   **1.00** |   **292.8268 us** |   **4.6858 us** |    **22.9555 us** |   **3414.99** |   **265.2669 us** |   **271.1174 us** |   **283.9039 us** |   **315.8173 us** |    **338.8224 us** |    **31.93** |     **-** |     **-** |         **146,855.59** |
       CompiledRegex |    32 |    45.9962 us |     3.6389 us |   0.16 |    47.8051 us |   0.7428 us |     3.6389 us |  20918.26 |    45.1616 us |    45.7047 us |    45.9962 us |    47.9599 us |     60.0982 us |     1.15 |     - |     - |           5,698.19 |
              Cached |    32 |    12.5125 us |     0.3912 us |   0.04 |    12.6401 us |   0.0875 us |     0.3912 us |  79113.53 |    12.3206 us |    12.3642 us |    12.5125 us |    12.6975 us |     13.6662 us |     0.66 |     - |     - |           3,282.27 |
 **BeforeOptimizations** |    **64** |   **546.0688 us** |    **28.0312 us** |   **1.00** |   **557.0718 us** |   **5.1178 us** |    **28.0312 us** |    **1795.1** |   **527.6012 us** |   **537.6436 us** |   **546.0688 us** |   **559.9123 us** |    **627.9537 us** |    **60.64** |     **-** |     **-** |         **279,017.52** |
       CompiledRegex |    64 |    90.2958 us |     7.2143 us |   0.17 |    92.3372 us |   1.3634 us |     7.2143 us |  10829.87 |    85.9964 us |    87.8590 us |    90.2958 us |    92.7650 us |    120.8274 us |     2.19 |     - |     - |          10,881.97 |
              Cached |    64 |    19.9810 us |     1.9469 us |   0.04 |    20.8816 us |   0.2415 us |     1.9469 us |  47889.12 |    19.3888 us |    19.7908 us |    19.9810 us |    21.4422 us |     29.1081 us |     1.04 |     - |     - |           5,012.08 |
 **BeforeOptimizations** |   **128** | **1,029.2094 us** |   **102.0501 us** |   **1.00** | **1,078.8463 us** |  **13.5169 us** |   **102.0501 us** |    **926.92** | **1,009.3223 us** | **1,019.7795 us** | **1,029.2094 us** | **1,102.4748 us** |  **1,516.8906 us** |   **133.77** |     **-** |     **-** |         **613,505.11** |
       CompiledRegex |   128 |   176.1462 us |    17.2224 us |   0.17 |   186.0988 us |   1.8464 us |    17.2224 us |   5373.49 |   171.5504 us |   174.2646 us |   176.1462 us |   198.0079 us |    246.6063 us |     4.34 |     - |     - |          24,603.48 |
              Cached |   128 |    35.9675 us |     2.3516 us |   0.03 |    36.6448 us |   0.5258 us |     2.3516 us |  27288.97 |    35.0461 us |    35.3999 us |    35.9675 us |    36.3813 us |     43.8258 us |     1.86 |     - |     - |           8,993.29 |
 **BeforeOptimizations** |   **256** | **2,048.3297 us** |    **55.6489 us** |   **1.00** | **2,065.7597 us** |  **12.4435 us** |    **55.6489 us** |    **484.08** | **2,027.3938 us** | **2,038.6227 us** | **2,048.3297 us** | **2,070.3766 us** |  **2,280.2523 us** |   **270.89** |     **-** |     **-** |       **1,242,172.75** |
       CompiledRegex |   256 |   353.9041 us |    43.7147 us |   0.17 |   374.3935 us |   4.3498 us |    43.7147 us |   2670.99 |   340.9913 us |   346.4168 us |   353.9041 us |   398.7195 us |    639.1389 us |     9.18 |     - |     - |          51,795.23 |
              Cached |   256 |    67.3854 us |     4.2621 us |   0.03 |    68.8437 us |   0.9087 us |     4.2621 us |  14525.67 |    66.2015 us |    66.6927 us |    67.3854 us |    67.9900 us |     81.1535 us |     3.89 |     - |     - |          18,591.98 |
 **BeforeOptimizations** |   **512** | **4,205.2031 us** |   **520.7559 us** |   **1.00** | **4,449.0647 us** |  **51.0643 us** |   **520.7559 us** |    **224.77** | **4,095.2516 us** | **4,145.9203 us** | **4,205.2031 us** | **4,531.1813 us** |  **7,145.6750 us** |   **583.78** |     **-** |     **-** |       **2,669,747.53** |
       CompiledRegex |   512 |   696.3177 us |    55.5569 us |   0.17 |   722.1530 us |  12.4229 us |    55.5569 us |   1384.75 |   688.8535 us |   692.1448 us |   696.3177 us |   708.8402 us |    875.5123 us |    18.55 |     - |     - |         103,760.16 |
              Cached |   512 |   133.3127 us |    13.1647 us |   0.03 |   139.3452 us |   1.3955 us |    13.1647 us |   7176.42 |   129.1644 us |   130.9702 us |   133.3127 us |   143.0185 us |    179.6522 us |     7.40 |     - |     - |          35,573.19 |
 **BeforeOptimizations** |  **1024** | **8,532.6563 us** | **1,241.0418 us** |   **1.00** | **9,013.7922 us** | **132.2955 us** | **1,241.0418 us** |    **110.94** | **8,179.9063 us** | **8,307.4156 us** | **8,532.6563 us** | **9,442.4531 us** | **17,940.4688 us** | **1,017.00** |     **-** |     **-** |       **4,661,115.18** |
       CompiledRegex |  1024 | 1,405.3367 us |    94.9641 us |   0.16 | 1,455.2636 us |  15.0151 us |    94.9641 us |    687.16 | 1,376.4438 us | 1,388.5652 us | 1,405.3367 us | 1,485.6641 us |  1,694.6727 us |    37.73 |     - |     - |         211,300.47 |
              Cached |  1024 |   258.9341 us |    16.3901 us |   0.03 |   265.8414 us |   2.9924 us |    16.3901 us |   3761.64 |   252.4414 us |   254.4937 us |   258.9341 us |   269.2091 us |    306.4555 us |    13.24 |     - |     - |          65,311.55 |

https://github.com/danielmarbach/MicroBenchmarks/blob/master/MicroBenchmarks/NServiceBus/ASQQeueNameGenerator.cs

The difference is GIGANTIC :dancers: 