### PR TITLE
Align connection string mapping to ASB API

### DIFF
--- a/src/AcceptanceTests/Sending/When_dispatching_to_other_account.cs
+++ b/src/AcceptanceTests/Sending/When_dispatching_to_other_account.cs
@@ -21,7 +21,7 @@
         }
 
         [Test]
-        public async Task Namespace_mapped_should_be_respected()
+        public async Task Account_mapped_should_be_respected()
         {
             await RunTest(AnotherAccountName);
         }
@@ -39,7 +39,7 @@
                     });
                 })
                 .WithEndpoint<Receiver>()
-                .Done(c => c.WasCalled) 
+                .Done(c => c.WasCalled)
                 .Run();
 
             Assert.IsTrue(context.WasCalled);
@@ -47,7 +47,7 @@
 
         const string AnotherAccountName = "another";
         const string DefaultAccountName = "default";
-        public static readonly string MainNamespaceConnectionString = Transports.Default.Settings.Get<string>("Transport.ConnectionString");
+        static readonly string MainNamespaceConnectionString = Transports.Default.Settings.Get<string>("Transport.ConnectionString");
 
         public class Context : ScenarioContext
         {
@@ -55,14 +55,17 @@
             public bool WasCalled { get; set; }
         }
 
-        public class Endpoint : EndpointConfigurationBuilder
+        class Endpoint : EndpointConfigurationBuilder
         {
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>(configuration =>
                 {
                     configuration.UseTransport<AzureStorageQueueTransport>()
-                        .UseAccountNamesInsteadOfConnectionStrings();
+                        .UseAccountNamesInsteadOfConnectionStrings()
+                        .DefaultAccountName(DefaultAccountName)
+                        .AccountRouting()
+                        .AddAccount(AnotherAccountName, Transports.Default.Settings.Get<string>("Transport.ConnectionString"));
                 }).AddMapping<MyMessage>(typeof(Receiver));
             }
         }
@@ -74,7 +77,10 @@
                 EndpointSetup<DefaultServer>(configuration =>
                 {
                     configuration.UseTransport<AzureStorageQueueTransport>()
-                        .UseAccountNamesInsteadOfConnectionStrings();
+                        .UseAccountNamesInsteadOfConnectionStrings()
+                        .DefaultAccountName(AnotherAccountName)
+                        .AccountRouting()
+                        .AddAccount(DefaultAccountName, Transports.Default.Settings.Get<string>("Transport.ConnectionString"));
                 });
             }
 

--- a/src/AcceptanceTests/Sending/When_dispatching_to_other_account.cs
+++ b/src/AcceptanceTests/Sending/When_dispatching_to_other_account.cs
@@ -62,11 +62,7 @@
                 EndpointSetup<DefaultServer>(configuration =>
                 {
                     configuration.UseTransport<AzureStorageQueueTransport>()
-                        .UseAccountNamesInsteadOfConnectionStrings(m =>
-                        {
-                            m.MapLocalAccount(DefaultAccountName);
-                            m.MapAccount(AnotherAccountName, Transports.Default.Settings.Get<string>("Transport.ConnectionString"));
-                        });
+                        .UseAccountNamesInsteadOfConnectionStrings();
                 }).AddMapping<MyMessage>(typeof(Receiver));
             }
         }
@@ -78,11 +74,7 @@
                 EndpointSetup<DefaultServer>(configuration =>
                 {
                     configuration.UseTransport<AzureStorageQueueTransport>()
-                        .UseAccountNamesInsteadOfConnectionStrings(m =>
-                        {
-                            m.MapLocalAccount(AnotherAccountName);
-                            m.MapAccount(DefaultAccountName, Transports.Default.Settings.Get<string>("Transport.ConnectionString"));
-                        });
+                        .UseAccountNamesInsteadOfConnectionStrings();
                 });
             }
 

--- a/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
+++ b/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
@@ -1,11 +1,9 @@
 ﻿namespace NServiceBus
 {
     
-    public sealed class AccountMapping
+    public class AccountRoutingSettings
     {
-        public AccountMapping() { }
-        public void MapAccount(string name, string connectionStringValue) { }
-        public void MapLocalAccount(string name) { }
+        public void AddAccount(string name, string connectionString) { }
     }
     public class AzureStorageQueueTransport : NServiceBus.Transports.TransportDefinition
     {
@@ -16,8 +14,9 @@
     }
     public class static AzureStorageTransportAddressingExtensions
     {
+        public static NServiceBus.AccountRoutingSettings AccountRouting(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> transportExtensions) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> DefaultAccountName(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> transportExtensions, string name) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseAccountNamesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config) { }
-        public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseAccountNamesInsteadOfConnectionStrings(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, System.Action<NServiceBus.AccountMapping> map) { }
     }
     public class static AzureStorageTransportExtensions
     {

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -4,11 +4,11 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Config;
-    using Transports;
     using Performance.TimeToBeReceived;
     using Routing;
     using Serialization;
     using Settings;
+    using Transports;
 
     class AzureStorageQueueInfrastructure : TransportInfrastructure
     {
@@ -62,6 +62,18 @@
         static AzureStorageAddressingSettings GetAddressing(ReadOnlySettings settings, string connectionString)
         {
             var addressing = settings.GetOrDefault<AzureStorageAddressingSettings>() ?? new AzureStorageAddressingSettings();
+
+            object useAccountNames;
+            if (settings.TryGet(WellKnownConfigurationKeys.UseAccountNamesInsteadOfConnectionStrings, out useAccountNames))
+            {
+                AccountConfigurations accounts;
+                if (settings.TryGet(out accounts) == false)
+                {
+                    accounts = new AccountConfigurations();
+                }
+
+                addressing.UseAccountNamesInsteadOfConnectionStrings(accounts.defaultName, accounts.mappings);
+            }
 
             addressing.Add(QueueAddress.DefaultStorageAccountName, connectionString, false);
 

--- a/src/Transport/Config/Extensions/AccountConfigurations.cs
+++ b/src/Transport/Config/Extensions/AccountConfigurations.cs
@@ -1,0 +1,29 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Holds mappings for used accounts.
+    /// </summary>
+    class AccountConfigurations
+    {
+        public void MapLocalAccount(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Should not be null or white space", nameof(name));
+            }
+
+            defaultName = name;
+        }
+
+        public void Add(string name, string connectionStringValue)
+        {
+            mappings.Add(name, connectionStringValue);
+        }
+
+        internal Dictionary<string, string> mappings = new Dictionary<string, string>();
+        internal string defaultName;
+    }
+}

--- a/src/Transport/Config/Extensions/AccountRoutingSettings.cs
+++ b/src/Transport/Config/Extensions/AccountRoutingSettings.cs
@@ -1,0 +1,24 @@
+namespace NServiceBus
+{
+    /// <summary>
+    /// Provides methods to define routing between Azure Storage accounts and map them to a logical name instead of using bare
+    /// connection strings.
+    /// </summary>
+    public class AccountRoutingSettings
+    {
+        internal AccountRoutingSettings(AccountConfigurations accounts)
+        {
+            this.accounts = accounts;
+        }
+
+        /// <summary>
+        /// Adds the mapping between the <paramref name="name" /> and its <paramref name="connectionString" />.
+        /// </summary>
+        public void AddAccount(string name, string connectionString)
+        {
+            accounts.Add(name, connectionString);
+        }
+
+        readonly AccountConfigurations accounts;
+    }
+}

--- a/src/Transport/Config/Extensions/AzureStorageAddressingSettings.cs
+++ b/src/Transport/Config/Extensions/AzureStorageAddressingSettings.cs
@@ -7,9 +7,9 @@
 
     sealed class AzureStorageAddressingSettings
     {
-        public void UseAccountNamesInsteadOfConnectionStrings(string defaultConnectionStringName, Dictionary<string, string> name2connectionString = null)
+        internal void UseAccountNamesInsteadOfConnectionStrings(string defaultConnectionStringName, Dictionary<string, string> name2connectionString = null)
         {
-            var hasAnyMapping = name2connectionString!= null && name2connectionString.Count > 0;
+            var hasAnyMapping = name2connectionString != null && name2connectionString.Count > 0;
             if (hasAnyMapping == false)
             {
                 return;
@@ -17,7 +17,7 @@
 
             if (string.IsNullOrWhiteSpace(defaultConnectionStringName))
             {
-                throw new ArgumentException(nameof(defaultConnectionStringName));
+                throw new Exception("The mapping of account names instead of connection strings is enabled, but the default connection string name isn\'t provided. Provide the default connection string name when adding more accounts");
             }
 
             this.defaultConnectionStringName = defaultConnectionStringName;

--- a/src/Transport/Config/WellKnownConfigurationKeys.cs
+++ b/src/Transport/Config/WellKnownConfigurationKeys.cs
@@ -10,5 +10,6 @@
         public const string MessageWrapperSerializationDefinition = "Transport.AzureStorageQueue.MessageWrapperSerializationDefinition";
         public const string Sha1Shortener = "Transport.AzureStorageQueue.Sha1Shortener";
         public const string DegreeOfReceiveParallelism = "Transport.AzureStorageQueue.DegreeOfReceiveParallelism";
+        public const string UseAccountNamesInsteadOfConnectionStrings = "Transport.AzureStorageQueue.UseAccountNamesInsteadOfConnectionStrings";
     }
 }

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -102,6 +102,8 @@
   <ItemGroup>
     <Compile Include="AzureMessageQueueCreator.cs" />
     <Compile Include="AzureStorageQueueInfrastructure.cs" />
+    <Compile Include="Config\Extensions\AccountConfigurations.cs" />
+    <Compile Include="Config\Extensions\AccountRoutingSettings.cs" />
     <Compile Include="Dispatcher.cs" />
     <Compile Include="MessageEnvelopeUnwrapper.cs" />
     <Compile Include="MessagePump.cs" />


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/871

On the basis of https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/119

#### Notes
##### API after the change

```
cfg.UseTransport<AzureStorageQueueTransport>()		
   .UseAccountNamesInsteadOfConnectionStrings()
   .DefaultAccountName(DefaultConnectionStringName)
   .AccountRouting()
   .AddAccount(AnotherConnectionStringName, anotherConnectionString);
```

##### Validation change

The PR changes the place where an exception can be thrown when using `UseAccountNamesInsteadOfConnectionStrings`. Currently the method only marks up the configuration as one using account names. The application is done during call to `AzureStorageQueueInfrastructure.ConfigureReceiveInfrastructure`. This changes the place when the validation of providing the default account name occurs. That's the only way I see it can be done if we want to provide a truly fluent interface with `UseAccountNamesInsteadOfConnectionStrings` possible to be called any time during configuration.