### PR TITLE
Change default values for receiver

### DIFF
--- a/src/Transport/Config/DefaultConfigurationValues.cs
+++ b/src/Transport/Config/DefaultConfigurationValues.cs
@@ -21,7 +21,7 @@
         }
 
         TimeSpan DefaultMessageInvisibleTime = TimeSpan.FromSeconds(30);
-        TimeSpan DefaultPeekInterval = TimeSpan.FromMilliseconds(50);
+        TimeSpan DefaultPeekInterval = TimeSpan.FromMilliseconds(125);
         TimeSpan DefaultMaximumWaitTimeWhenIdle = TimeSpan.FromSeconds(1);
         const int DefaultBatchSize = 32;
         const string DefaultConnectionString = "";

--- a/src/Transport/Config/DefaultConfigurationValues.cs
+++ b/src/Transport/Config/DefaultConfigurationValues.cs
@@ -22,7 +22,7 @@
 
         TimeSpan DefaultMessageInvisibleTime = TimeSpan.FromSeconds(30);
         TimeSpan DefaultPeekInterval = TimeSpan.FromMilliseconds(125);
-        TimeSpan DefaultMaximumWaitTimeWhenIdle = TimeSpan.FromSeconds(1);
+        TimeSpan DefaultMaximumWaitTimeWhenIdle = TimeSpan.FromSeconds(30);
         const int DefaultBatchSize = 32;
         const string DefaultConnectionString = "";
     }


### PR DESCRIPTION
`DefaultPeekInterval` was set at `50`. @danielmarbach calculations show that https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/139#issuecomment-238480885 this saturates the throughput of a single storage queue. This PR increase the value to the proposed one.