### PR TITLE
Poison messages handling

### DIFF
--- a/src/Transport/AzureMessageQueueReceiver.cs
+++ b/src/Transport/AzureMessageQueueReceiver.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.AzureStorageQueues
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Logging;
     using Microsoft.WindowsAzure.Storage.Queue;
 
     class AzureMessageQueueReceiver
@@ -68,13 +69,24 @@ namespace NServiceBus.AzureStorageQueues
             List<MessageRetrieved> messages = null;
             foreach (var rawMessage in rawMessages)
             {
-                if (!messageFound)
+                try
                 {
-                    messages = new List<MessageRetrieved>(BatchSize);
-                    messageFound = true;
-                }
+                    var wrapper = unwrapper.Unwrap(rawMessage);
 
-                messages.Add(new MessageRetrieved(unwrapper, rawMessage, inputQueue));
+                    if (!messageFound)
+                    {
+                        messages = new List<MessageRetrieved>(BatchSize);
+                        messageFound = true;
+                    }
+
+                    messages.Add(new MessageRetrieved(wrapper, rawMessage, inputQueue));
+                }
+                catch (Exception ex)
+                {
+                    await errorQueue.AddMessageAsync(rawMessage).ConfigureAwait(false);
+                    Logger.Error($"Failed to deserialize message envelope for message with id {rawMessage.Id}. Make sure the configured serializer is used across all endpoints or configure the message wrapper serializer for this endpoint using the `SerializeMessageWrapperWith` extension on the transport configuration. Please refer to the Azure Storage Queue Transport configuration documentation for more details.", ex);
+                    await inputQueue.DeleteMessageAsync(rawMessage).ConfigureAwait(false);
+                }
             }
 
             if (!messageFound)
@@ -106,5 +118,7 @@ namespace NServiceBus.AzureStorageQueues
         TimeSpan timeToDelayNextPeek;
 
         static List<MessageRetrieved> noMessagesFound = new List<MessageRetrieved>();
+
+        static readonly ILog Logger = LogManager.GetLogger(typeof(AzureMessageQueueReceiver));
     }
 }

--- a/src/Transport/AzureMessageQueueReceiver.cs
+++ b/src/Transport/AzureMessageQueueReceiver.cs
@@ -41,22 +41,28 @@ namespace NServiceBus.AzureStorageQueues
         /// </summary>
         public int BatchSize { get; set; }
 
-        public async Task Init(string address)
+        public async Task Init(string inputQueueAddress, string errorQueueAddress)
         {
-            var queueName = addressGenerator.GetQueueName(address);
-
-            azureQueue = client.GetQueueReference(queueName);
-            await azureQueue.CreateIfNotExistsAsync().ConfigureAwait(false);
+            inputQueue = await GetQueue(inputQueueAddress).ConfigureAwait(false);
+            errorQueue = await GetQueue(errorQueueAddress).ConfigureAwait(false);
 
             if (PurgeOnStartup)
             {
-                await azureQueue.ClearAsync().ConfigureAwait(false);
+                await inputQueue.ClearAsync().ConfigureAwait(false);
             }
+        }
+
+        async Task<CloudQueue> GetQueue(string address)
+        {
+            var name = addressGenerator.GetQueueName(address);
+            var queue = client.GetQueueReference(name);
+            await queue.CreateIfNotExistsAsync().ConfigureAwait(false);
+            return queue;
         }
 
         internal async Task<List<MessageRetrieved>> Receive(CancellationToken token)
         {
-            var rawMessages = await azureQueue.GetMessagesAsync(BatchSize, MessageInvisibleTime, null, null, token).ConfigureAwait(false);
+            var rawMessages = await inputQueue.GetMessagesAsync(BatchSize, MessageInvisibleTime, null, null, token).ConfigureAwait(false);
 
             var messageFound = false;
             List<MessageRetrieved> messages = null;
@@ -68,7 +74,7 @@ namespace NServiceBus.AzureStorageQueues
                     messageFound = true;
                 }
 
-                messages.Add(new MessageRetrieved(unwrapper, rawMessage, azureQueue));
+                messages.Add(new MessageRetrieved(unwrapper, rawMessage, inputQueue));
             }
 
             if (!messageFound)
@@ -94,7 +100,8 @@ namespace NServiceBus.AzureStorageQueues
 
         QueueAddressGenerator addressGenerator;
 
-        CloudQueue azureQueue;
+        CloudQueue inputQueue;
+        CloudQueue errorQueue;
         CloudQueueClient client;
         TimeSpan timeToDelayNextPeek;
 

--- a/src/Transport/MessagePump.cs
+++ b/src/Transport/MessagePump.cs
@@ -153,7 +153,7 @@
         {
             try
             {
-                var message = retrieved.Unwrap();
+                var message = retrieved.Wrapper;
                 addressing.ApplyMappingToLogicalName(message.Headers);
 
                 await receiveStrategy.Receive(retrieved, message).ConfigureAwait(false);

--- a/src/Transport/MessagePump.cs
+++ b/src/Transport/MessagePump.cs
@@ -30,7 +30,7 @@
 
             receiveStrategy = ReceiveStrategy.BuildReceiveStrategy(onMessage, onError, settings.RequiredTransactionMode);
 
-            return messageReceiver.Init(settings.InputQueue);
+            return messageReceiver.Init(settings.InputQueue, settings.ErrorQueue);
         }
 
         public void Start(PushRuntimeSettings limitations)

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AzureStorageQueues
 {
     using System;
-    using System.Runtime.Serialization;
     using System.Threading.Tasks;
     using Azure.Transports.WindowsAzureStorageQueues;
     using Microsoft.WindowsAzure.Storage;
@@ -9,30 +8,14 @@
 
     class MessageRetrieved
     {
-        public MessageRetrieved(MessageEnvelopeUnwrapper unpacker, CloudQueueMessage rawMessage, CloudQueue azureQueue)
+        public MessageRetrieved(MessageWrapper wrapper, CloudQueueMessage rawMessage, CloudQueue azureQueue)
         {
-            this.unpacker = unpacker;
+            Wrapper = wrapper;
             this.rawMessage = rawMessage;
             this.azureQueue = azureQueue;
         }
 
         public int DequeueCount => rawMessage.DequeueCount;
-
-        /// <summary>
-        /// Unwraps the raw message.
-        /// </summary>
-        /// <returns>Returns the message wrapper.</returns>
-        public MessageWrapper Unwrap()
-        {
-            try
-            {
-                return unpacker.Unwrap(rawMessage);
-            }
-            catch (Exception ex)
-            {
-                throw new SerializationException($"Failed to deserialize message envelope for message with id {rawMessage.Id}. Make sure the configured serializer is used across all endpoints or configure the message wrapper serializer for this endpoint using the `SerializeMessageWrapperWith` extension on the transport configuration. Please refer to the Azure Storage Queue Transport configuration documentation for more details.", ex);
-            }
-        }
 
         /// <summary>
         /// Acknowledges the successful processing of the message.
@@ -62,9 +45,8 @@
             }
         }
 
-        MessageEnvelopeUnwrapper unpacker;
-
-        CloudQueue azureQueue;
-        CloudQueueMessage rawMessage;
+        public readonly MessageWrapper Wrapper;
+        readonly CloudQueue azureQueue;
+        readonly CloudQueueMessage rawMessage;
     }
 }


### PR DESCRIPTION
Addresses #142

Currently, when a malformed message is retrieved and cannot be deserialized properly ASQ handles it poorly. This PR addresses this need by explicitly catching any serialization related problems and putting a problematic message directly to the error queue.