### PR TITLE
[WIP] Changed the ToTransportAddress behavior to only used relevant fields

### DIFF
--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Text;
     using System.Threading.Tasks;
     using Config;
     using Performance.TimeToBeReceived;
@@ -120,7 +121,19 @@
 
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
-            return logicalAddress.ToString();
+            var queue = new StringBuilder(logicalAddress.QueueName);
+
+            if (logicalAddress.Discriminator != null)
+            {
+                queue.Append("-" + logicalAddress.Discriminator);
+            }
+
+            if (logicalAddress.Qualifier != null)
+            {
+                queue.Append("." + logicalAddress.Qualifier);
+            }
+
+            return queue.ToString();
         }
 
         ReadOnlySettings settings;


### PR DESCRIPTION
The previous version with ToString would include all instance properties (if provided) which is not something we want in the address.