### PR TITLE
Made transport address translation explicit

### DIFF
--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Text;
     using System.Threading.Tasks;
     using Config;
     using Performance.TimeToBeReceived;
@@ -120,7 +121,19 @@
 
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
-            return logicalAddress.ToString();
+            var queue = new StringBuilder(logicalAddress.EndpointInstance.Endpoint);
+
+            if (logicalAddress.EndpointInstance.Discriminator != null)
+            {
+                queue.Append("-" + logicalAddress.EndpointInstance.Discriminator);
+            }
+
+            if (logicalAddress.Qualifier != null)
+            {
+                queue.Append("." + logicalAddress.Qualifier);
+            }
+
+            return queue.ToString();
         }
 
         ReadOnlySettings settings;


### PR DESCRIPTION
The `ToString` was meant to be a debugging helper. It incudes instance properties which you don't want to have in the default form in the transport address.