### PR TITLE
Allow custom envelope unwrapping

### DIFF
--- a/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
@@ -351,6 +351,7 @@
     <Compile Include="ConfigureAzureStorageQueueTransport.cs" />
     <Compile Include="NamespaceSetup.cs" />
     <Compile Include="ConsoleLoggerFactory.cs" />
+    <Compile Include="Receiving\When_receiving_a_raw_json_message.cs" />
     <Compile Include="Receiving\When_receiving_a_message.cs" />
     <Compile Include="Sending\When_delaying_messages_natively.cs" />
     <Compile Include="Sending\When_dispatching_fails.cs" />

--- a/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues.AcceptanceTests.Receiving
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Threading.Tasks;
@@ -34,11 +33,10 @@
 
                         var cloudQueueMessage = new CloudQueueMessage(jsonPayload);
 
-                        var connectionString = Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString");
-
+                        var connectionString = Utils.GetEnvConfiguredConnectionString();
                         var storageAccount = CloudStorageAccount.Parse(connectionString);
                         var queueClient = storageAccount.CreateCloudQueueClient();
-                        var queue = queueClient.GetQueueReference("receivingarawjsonmessage-receiver-retries");
+                        var queue = queueClient.GetQueueReference("receivingarawjsonmessage-receiver");
 
                         return queue.AddMessageAsync(cloudQueueMessage);
                     });

--- a/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues.AcceptanceTests.Receiving
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Queue;
+    using Newtonsoft.Json;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_receiving_a_raw_json_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task ShouldConsumeIt()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<Receiver>(b =>
+                {
+
+                    b.When((bus, c) =>
+                    {
+                        var jsonPayload = JsonConvert.SerializeObject(new MyMessage(), Formatting.Indented, new JsonSerializerSettings
+                        {
+                            TypeNameHandling = TypeNameHandling.All
+                        });
+
+                        var message = new CloudQueueMessage(jsonPayload);
+
+                        var connectionString = Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString");
+
+                        var storageAccount = CloudStorageAccount.Parse(connectionString);
+                        var queueClient = storageAccount.CreateCloudQueueClient();
+                        var queue = queueClient.GetQueueReference("receivingarawjsonmessage-receiver-retries");
+
+                        return queue.AddMessageAsync(message);
+                    });
+                })
+                .Done(c => c.GotMessage)
+                .Run();
+
+            Assert.True(ctx.GotMessage);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool GotMessage { get; set; }
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        class MyMessage : IMessage
+        {
+        }
+
+        class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public MyMessageHandler(Context ctx)
+            {
+                this.ctx = ctx;
+            }
+
+            public Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                ctx.GotMessage = true;
+
+                return Task.FromResult(0);
+            }
+
+            Context ctx;
+        }
+    }
+}

--- a/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
@@ -52,7 +52,6 @@
         {
             public bool GotMessage { get; set; }
             public MyMessage MessageReceived { get; set; }
-            public IReadOnlyDictionary<string, string> HeadersReceived { get; set; }
         }
 
         class Receiver : EndpointConfigurationBuilder
@@ -110,7 +109,6 @@
             public Task Handle(MyMessage message, IMessageHandlerContext context)
             {
                 ctx.MessageReceived = message;
-                ctx.HeadersReceived = context.MessageHeaders;
                 ctx.GotMessage = true;
 
                 return Task.FromResult(0);

--- a/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
@@ -1,14 +1,19 @@
 ﻿namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues.AcceptanceTests.Receiving
 {
     using System;
+    using System.Collections.Generic;
+    using System.IO;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using MessageInterfaces;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Queue;
     using Newtonsoft.Json;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
+    using Serialization;
+    using Settings;
 
     public class When_receiving_a_raw_json_message : NServiceBusAcceptanceTest
     {
@@ -21,12 +26,16 @@
 
                     b.When((bus, c) =>
                     {
-                        var jsonPayload = JsonConvert.SerializeObject(new MyMessage(), Formatting.Indented, new JsonSerializerSettings
+                        var message = new MyMessage
                         {
-                            TypeNameHandling = TypeNameHandling.All
+                            SomeProperty = "Test"
+                        };
+                        var jsonPayload = JsonConvert.SerializeObject(message, new JsonSerializerSettings
+                        {
+                            TypeNameHandling = TypeNameHandling.All //we need this in order fo $type="x" to be embedded in the json
                         });
 
-                        var message = new CloudQueueMessage(jsonPayload);
+                        var cloudQueueMessage = new CloudQueueMessage(jsonPayload);
 
                         var connectionString = Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString");
 
@@ -34,30 +43,112 @@
                         var queueClient = storageAccount.CreateCloudQueueClient();
                         var queue = queueClient.GetQueueReference("receivingarawjsonmessage-receiver-retries");
 
-                        return queue.AddMessageAsync(message);
+                        return queue.AddMessageAsync(cloudQueueMessage);
                     });
                 })
                 .Done(c => c.GotMessage)
                 .Run();
 
             Assert.True(ctx.GotMessage);
+            Assert.AreEqual("Test", ctx.MessageReceived.SomeProperty);
         }
 
         class Context : ScenarioContext
         {
             public bool GotMessage { get; set; }
+            public MyMessage MessageReceived { get; set; }
         }
 
         class Receiver : EndpointConfigurationBuilder
         {
             public Receiver()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.UseSerialization<NServiceBus.JsonSerializer>();
+                    config.UseTransport<AzureStorageQueueTransport>()
+                        .SerializeMessageWrapperWith<NativeAwareSerializer>();
+                });
+            }
+        }
+
+
+        class NativeAwareSerializer : SerializationDefinition
+        {
+            public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
+            {
+                return mapper => new Serializer();
+            }
+
+            class Serializer : IMessageSerializer
+            {
+                public void Serialize(object message, Stream stream)
+                {
+                    using (var streamWriter = new StreamWriter(stream))
+                    {
+                        using (var jsonWriter = new JsonTextWriter(streamWriter))
+                        {
+                            jsonSerializer.Serialize(jsonWriter, message);
+                            jsonWriter.Flush();
+                        }
+                    }
+                }
+
+                public object[] Deserialize(Stream stream, IList<Type> messageTypes = null)
+                {
+
+                    using (var streamReader = new StreamReader(stream))
+                    using (var textReader = new JsonTextReader(streamReader))
+                    {
+                        var wrapper = jsonSerializer.Deserialize<MessageWrapper>(textReader);
+
+                        if (!string.IsNullOrEmpty(wrapper.Id))
+                        {
+                            return new object[] { wrapper };
+                        }
+                        stream.Seek(0, SeekOrigin.Begin);
+                        return ReadNative(stream);
+                    }
+                }
+
+                static object[] ReadNative(Stream stream)
+                {
+                    var nativeWrapper = new MessageWrapper();
+
+                    nativeWrapper.Id = Guid.NewGuid().ToString(); //todo: How to deal with this?
+                    nativeWrapper.Headers = new Dictionary<string, string>();
+
+                    nativeWrapper.Body = ReadStream(stream);
+
+                    return new object[]
+                    {
+                        nativeWrapper
+                    };
+                }
+
+                static byte[] ReadStream(Stream input)
+                {
+                    var buffer = new byte[16 * 1024];
+                    using (var ms = new MemoryStream())
+                    {
+                        int read;
+                        while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            ms.Write(buffer, 0, read);
+                        }
+                        return ms.ToArray();
+                    }
+                }
+
+                public string ContentType { get; } = "application/json";
+
+                JsonSerializer jsonSerializer = JsonSerializer.Create();
             }
         }
 
         class MyMessage : IMessage
         {
+            public string SomeProperty { get; set; }
         }
 
         class MyMessageHandler : IHandleMessages<MyMessage>
@@ -69,6 +160,7 @@
 
             public Task Handle(MyMessage message, IMessageHandlerContext context)
             {
+                ctx.MessageReceived = message;
                 ctx.GotMessage = true;
 
                 return Task.FromResult(0);

--- a/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
+++ b/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
@@ -28,6 +28,7 @@
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> SerializeMessageWrapperWith<TSerializationDefinition>(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config)
             where TSerializationDefinition : NServiceBus.Serialization.SerializationDefinition, new () { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseNativeTimeouts(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, string timeoutTableName) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UnwrapMessagesWith(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, NServiceBus.AzureStorageQueues.IMessageEnvelopeUnwrapper unwrapper) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseSha1ForShortening(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config) { }
     }
     [System.ObsoleteAttribute("This class was replaced by extension methods on endpointConfiguration.UseTranspor" +
@@ -173,6 +174,14 @@ namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues
     public class SendResourceManager
     {
         public SendResourceManager() { }
+    }
+}
+namespace NServiceBus.AzureStorageQueues
+{
+    
+    public interface IMessageEnvelopeUnwrapper
+    {
+        NServiceBus.Azure.Transports.WindowsAzureStorageQueues.MessageWrapper Unwrap(Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage rawMessage);
     }
 }
 namespace NServiceBus.Config

--- a/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
+++ b/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
@@ -176,14 +176,6 @@ namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues
         public SendResourceManager() { }
     }
 }
-namespace NServiceBus.AzureStorageQueues
-{
-    
-    public interface IMessageEnvelopeUnwrapper
-    {
-        NServiceBus.Azure.Transports.WindowsAzureStorageQueues.MessageWrapper Unwrap(Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage rawMessage);
-    }
-}
 namespace NServiceBus.Config
 {
     

--- a/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
+++ b/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
@@ -27,8 +27,8 @@
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> PeekInterval(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, System.TimeSpan value) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> SerializeMessageWrapperWith<TSerializationDefinition>(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config)
             where TSerializationDefinition : NServiceBus.Serialization.SerializationDefinition, new () { }
+        public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UnwrapMessagesWith(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, System.Func<Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage, NServiceBus.Azure.Transports.WindowsAzureStorageQueues.MessageWrapper> unwrapper) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseNativeTimeouts(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, string timeoutTableName) { }
-        public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UnwrapMessagesWith(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, NServiceBus.AzureStorageQueues.IMessageEnvelopeUnwrapper unwrapper) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseSha1ForShortening(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config) { }
     }
     [System.ObsoleteAttribute("This class was replaced by extension methods on endpointConfiguration.UseTranspor" +

--- a/src/Transport/AzureMessageQueueReceiver.cs
+++ b/src/Transport/AzureMessageQueueReceiver.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.AzureStorageQueues
 
     class AzureMessageQueueReceiver
     {
-        public AzureMessageQueueReceiver(MessageEnvelopeUnwrapper unwrapper, CloudQueueClient client, QueueAddressGenerator addressGenerator, BackoffStrategy backoffStrategy)
+        public AzureMessageQueueReceiver(IMessageEnvelopeUnwrapper unwrapper, CloudQueueClient client, QueueAddressGenerator addressGenerator, BackoffStrategy backoffStrategy)
         {
             this.unwrapper = unwrapper;
             this.client = client;
@@ -72,7 +72,7 @@ namespace NServiceBus.AzureStorageQueues
             return messageFound ? messages : noMessagesFound;
         }
 
-        MessageEnvelopeUnwrapper unwrapper;
+        IMessageEnvelopeUnwrapper unwrapper;
 
         QueueAddressGenerator addressGenerator;
 

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -58,7 +58,11 @@
                 () =>
                 {
                     var addressing = GetAddressing(settings, connectionString);
-                    var unwrapper = new MessageEnvelopeUnwrapper(serializer);
+
+                    var unwrapper = settings.HasSetting<IMessageEnvelopeUnwrapper>() ?
+                        settings.GetOrDefault<IMessageEnvelopeUnwrapper>() :
+                        new DefaultMessageEnvelopeUnwrapper(serializer);
+
                     var addressGenerator = GetAddressGenerator(settings);
                     var maximumWaitTime = settings.Get<TimeSpan>(WellKnownConfigurationKeys.ReceiverMaximumWaitTimeWhenIdle);
                     var peekInterval = settings.Get<TimeSpan>(WellKnownConfigurationKeys.ReceiverPeekInterval);

--- a/src/Transport/Config/AzureStorageTransportExtensions.cs
+++ b/src/Transport/Config/AzureStorageTransportExtensions.cs
@@ -6,6 +6,7 @@ namespace NServiceBus
     using AzureStorageQueues;
     using AzureStorageQueues.Config;
     using Configuration.AdvanceExtensibility;
+    using Microsoft.WindowsAzure.Storage.Queue;
     using Serialization;
 
     public static class AzureStorageTransportExtensions
@@ -72,11 +73,11 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Registers a custom unwrapper to convert native messages to <see cref="MessageWrapper" />. This is needed when receiving raw json/xml/etc messages from non NServiceBus endpoints. 
+        /// Registers a custom unwrapper to convert native messages to <see cref="MessageWrapper" />. This is needed when receiving raw json/xml/etc messages from non NServiceBus endpoints.
         /// </summary>
-        public static TransportExtensions<AzureStorageQueueTransport> UnwrapMessagesWith(this TransportExtensions<AzureStorageQueueTransport> config,IMessageEnvelopeUnwrapper unwrapper)
+        public static TransportExtensions<AzureStorageQueueTransport> UnwrapMessagesWith(this TransportExtensions<AzureStorageQueueTransport> config, Func<CloudQueueMessage, MessageWrapper> unwrapper)
         {
-            config.GetSettings().Set<IMessageEnvelopeUnwrapper>(unwrapper);
+            config.GetSettings().Set<IMessageEnvelopeUnwrapper>(new UserProvidedEnvelopeUnwrapper(unwrapper));
             return config;
         }
 

--- a/src/Transport/Config/AzureStorageTransportExtensions.cs
+++ b/src/Transport/Config/AzureStorageTransportExtensions.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Text.RegularExpressions;
     using Azure.Transports.WindowsAzureStorageQueues;
+    using AzureStorageQueues;
     using AzureStorageQueues.Config;
     using Configuration.AdvanceExtensibility;
     using Serialization;
@@ -67,6 +68,15 @@ namespace NServiceBus
             where TSerializationDefinition : SerializationDefinition, new()
         {
             config.GetSettings().Set(WellKnownConfigurationKeys.MessageWrapperSerializationDefinition, new TSerializationDefinition());
+            return config;
+        }
+
+        /// <summary>
+        /// Registers a custom unwrapper to convert native messages to <see cref="MessageWrapper" />. This is needed when receiving raw json/xml/etc messages from non NServiceBus endpoints. 
+        /// </summary>
+        public static TransportExtensions<AzureStorageQueueTransport> UnwrapMessagesWith(this TransportExtensions<AzureStorageQueueTransport> config,IMessageEnvelopeUnwrapper unwrapper)
+        {
+            config.GetSettings().Set<IMessageEnvelopeUnwrapper>(unwrapper);
             return config;
         }
 

--- a/src/Transport/DefaultMessageEnvelopeUnwrapper.cs
+++ b/src/Transport/DefaultMessageEnvelopeUnwrapper.cs
@@ -6,9 +6,9 @@ namespace NServiceBus.AzureStorageQueues
     using Azure.Transports.WindowsAzureStorageQueues;
     using Microsoft.WindowsAzure.Storage.Queue;
 
-    class MessageEnvelopeUnwrapper
+    class DefaultMessageEnvelopeUnwrapper : IMessageEnvelopeUnwrapper
     {
-        public MessageEnvelopeUnwrapper(MessageWrapperSerializer messageSerializer)
+        public DefaultMessageEnvelopeUnwrapper(MessageWrapperSerializer messageSerializer)
         {
             messageWrapperSerializer = messageSerializer;
         }

--- a/src/Transport/Dispatcher.cs
+++ b/src/Transport/Dispatcher.cs
@@ -140,7 +140,7 @@
         QueueAddressGenerator addressGenerator;
         AzureStorageAddressingSettings addressing;
         readonly CreateQueueClients createQueueClients;
-        
+
         ILog logger = LogManager.GetLogger(typeof(Dispatcher));
         ConcurrentDictionary<string, Task<bool>> rememberExistence = new ConcurrentDictionary<string, Task<bool>>();
         readonly MessageWrapperSerializer serializer;

--- a/src/Transport/IMessageEnvelopeUnwrapper.cs
+++ b/src/Transport/IMessageEnvelopeUnwrapper.cs
@@ -3,16 +3,8 @@ namespace NServiceBus.AzureStorageQueues
     using Azure.Transports.WindowsAzureStorageQueues;
     using Microsoft.WindowsAzure.Storage.Queue;
 
-    /// <summary>
-    /// Extracts a native cloud queue message to the internal message wrapper format.
-    /// </summary>
-    public interface IMessageEnvelopeUnwrapper
+    interface IMessageEnvelopeUnwrapper
     {
-        /// <summary>
-        /// Unwraps the given message.
-        /// </summary>
-        /// <param name="rawMessage">The raw cloud queue message received from the Azure storage queue.</param>
-        /// <returns></returns>
         MessageWrapper Unwrap(CloudQueueMessage rawMessage);
     }
 }

--- a/src/Transport/IMessageEnvelopeUnwrapper.cs
+++ b/src/Transport/IMessageEnvelopeUnwrapper.cs
@@ -1,0 +1,18 @@
+namespace NServiceBus.AzureStorageQueues
+{
+    using Azure.Transports.WindowsAzureStorageQueues;
+    using Microsoft.WindowsAzure.Storage.Queue;
+
+    /// <summary>
+    /// Extracts a native cloud queue message to the internal message wrapper format.
+    /// </summary>
+    public interface IMessageEnvelopeUnwrapper
+    {
+        /// <summary>
+        /// Unwraps the given message.
+        /// </summary>
+        /// <param name="rawMessage">The raw cloud queue message received from the Azure storage queue.</param>
+        /// <returns></returns>
+        MessageWrapper Unwrap(CloudQueueMessage rawMessage);
+    }
+}

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -9,7 +9,7 @@
 
     class MessageRetrieved
     {
-        public MessageRetrieved(MessageEnvelopeUnwrapper unwrapper, CloudQueueMessage rawMessage, CloudQueue inputQueue, CloudQueue errorQueue)
+        public MessageRetrieved(IMessageEnvelopeUnwrapper unwrapper, CloudQueueMessage rawMessage, CloudQueue inputQueue, CloudQueue errorQueue)
         {
             this.unwrapper = unwrapper;
             this.errorQueue = errorQueue;
@@ -87,7 +87,7 @@
         readonly CloudQueue inputQueue;
         readonly CloudQueueMessage rawMessage;
         readonly CloudQueue errorQueue;
-        readonly MessageEnvelopeUnwrapper unwrapper;
+        readonly IMessageEnvelopeUnwrapper unwrapper;
     }
 
     class LeaseTimeoutException : Exception

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -139,6 +139,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="TaskEx.cs" />
     <Compile Include="TransportOperationExtensions.cs" />
+    <Compile Include="UserProvidedEnvelopeUnwrapper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -114,7 +114,8 @@
     <Compile Include="DelayDelivery\TimeoutEntity.cs" />
     <Compile Include="DelayDelivery\TimeoutsPoller.cs" />
     <Compile Include="Dispatcher.cs" />
-    <Compile Include="MessageEnvelopeUnwrapper.cs" />
+    <Compile Include="IMessageEnvelopeUnwrapper.cs" />
+    <Compile Include="DefaultMessageEnvelopeUnwrapper.cs" />
     <Compile Include="MessagePump.cs" />
     <Compile Include="obsoletes.cs" />
     <Compile Include="ReceiveStrategy.cs" />

--- a/src/Transport/UserProvidedEnvelopeUnwrapper.cs
+++ b/src/Transport/UserProvidedEnvelopeUnwrapper.cs
@@ -1,0 +1,22 @@
+namespace NServiceBus.AzureStorageQueues
+{
+    using System;
+    using Azure.Transports.WindowsAzureStorageQueues;
+    using Microsoft.WindowsAzure.Storage.Queue;
+
+    class UserProvidedEnvelopeUnwrapper : IMessageEnvelopeUnwrapper
+    {
+        public UserProvidedEnvelopeUnwrapper(Func<CloudQueueMessage, MessageWrapper> unwrapper)
+        {
+            this.unwrapper = unwrapper;
+        }
+
+        public MessageWrapper Unwrap(CloudQueueMessage rawMessage)
+        {
+
+            return unwrapper(rawMessage);
+        }
+
+        Func<CloudQueueMessage, MessageWrapper> unwrapper;
+    }
+}


### PR DESCRIPTION
This PR adds a better extension point to support native integration scenarios where the unwrapper gets full access to the native cloud message.

If we merge this in we should add a native integration sample to docs similar to Sql and Rabbit.
