### PR TITLE
Make When_receiving_a_raw_json_message message public for 6.1 preparation

### DIFF
--- a/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_a_raw_json_message.cs
@@ -94,7 +94,7 @@
         static JsonSerializer jsonSerializer = JsonSerializer.Create();
 
 
-        class MyMessage : IMessage
+        public class MyMessage : IMessage
         {
             public string SomeProperty { get; set; }
         }


### PR DESCRIPTION
Currently, #170 is failing because the merge commit contains `When_receiving_a_raw_json_message `with a message type that is not public.