### PR TITLE
Adding next-version attribute to GitVersion.yaml

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+next-version: 6.2.2
 assembly-versioning-scheme: Major
 branches:
   develop:


### PR DESCRIPTION
This amends `GitVersion.yaml` to mimic tag `6.2.1` on the `support-6.2` branch that did not include this tag resulting in wrongly versioned nuget.