### PR TITLE
nservicebus.azurestoragequeues.nuspec dependencies updated to correct versions

### DIFF
--- a/packaging/nuget/nservicebus.azurestoragequeues.nuspec
+++ b/packaging/nuget/nservicebus.azurestoragequeues.nuspec
@@ -14,11 +14,11 @@
     <copyright>Copyright 2010-2014 NServiceBus. All rights reserved</copyright>
     <tags>nservicebus servicebus msmq cqrs publish subscribe</tags>
     <dependencies>
-      <dependency id="WindowsAzure.Storage" version="[3.1.0.1, 5.0.0.0)" />
-      <dependency id="Microsoft.Data.Edm" version="[5.6.0.0, 6.0.0.0)" />
-      <dependency id="Microsoft.Data.OData" version="[5.6.0.0, 6.0.0.0)" />
-      <dependency id="NServiceBus" version="[5.1.2.0, 6.0.0.0)" />
-      <dependency id="System.Spatial" version="[5.6.0.0, 6.0.0.0)" />
+      <dependency id="WindowsAzure.Storage" version="[4.3.0.0, 5.0.0.0)" />
+      <dependency id="Microsoft.Data.Edm" version="[5.6.2.0, 6.0.0.0)" />
+      <dependency id="Microsoft.Data.OData" version="[5.6.2.0, 6.0.0.0)" />
+      <dependency id="NServiceBus" version="[5.2.21.0, 6.0.0.0)" />
+      <dependency id="System.Spatial" version="[5.6.2.0, 6.0.0.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Previous version of `nservicebus.azurestoragequeues.nuspec` had wrong references both to `NServiceBus.Core` and `WindowsAzure.Storage`. That resulted in problems both when installing the package in fresh project as well as doing nuget update.