### PR TITLE
Removing attribute enforcing next-version

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,3 @@
-next-version: 6.2.2
 assembly-versioning-scheme: Major
 branches:
   develop:


### PR DESCRIPTION
Removing `next-version` attribute. This has been used to enforce proper version for nupkg without 6.2.2 tag on the repository.