### PR TITLE
Porting #193 to develop

### DIFF
--- a/src/AcceptanceTests/Configuration/When_receiving_from_another_account_wo_aliases.cs
+++ b/src/AcceptanceTests/Configuration/When_receiving_from_another_account_wo_aliases.cs
@@ -8,7 +8,7 @@
 
     public class When_receiving_from_another_account_wo_aliases : NServiceBusAcceptanceTest
     {
-        const string ReplyToValue = "queue@DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;";
+        const string UnmappedConnectionString = "queue@DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;";
 
         [Test]
         public async Task Should_properly_handle_it()
@@ -18,7 +18,7 @@
                 {
                     var options = new SendOptions();
                     options.RouteToThisEndpoint();
-                    options.RouteReplyTo(ReplyToValue);
+                    options.RouteReplyTo(UnmappedConnectionString);
                     return s.Send(new MyMessage(), options);
                 }))
                 .Done(c => c.HandlerCalled)
@@ -55,7 +55,7 @@
 
             public Task Handle(MyMessage message, IMessageHandlerContext context)
             {
-                if (context.MessageHeaders[Headers.ReplyToAddress] == ReplyToValue)
+                if (context.MessageHeaders[Headers.ReplyToAddress] == UnmappedConnectionString)
                 {
                     scenarioContext.HandlerCalled = true;
                 }

--- a/src/AcceptanceTests/Configuration/When_receiving_from_another_account_wo_aliases.cs
+++ b/src/AcceptanceTests/Configuration/When_receiving_from_another_account_wo_aliases.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus.AcceptanceTests.WindowsAzureStorageQueues.Configuration
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_receiving_from_another_account_wo_aliases : NServiceBusAcceptanceTest
+    {
+        const string ReplyToValue = "queue@DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;";
+
+        [Test]
+        public async Task Should_properly_handle_it()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Receiver>(c => c.When(s =>
+                {
+                    var options = new SendOptions();
+                    options.RouteToThisEndpoint();
+                    options.RouteReplyTo(ReplyToValue);
+                    return s.Send(new MyMessage(), options);
+                }))
+                .Done(c => c.HandlerCalled)
+                .Run(TimeSpan.FromSeconds(15));
+
+            Assert.True(context.HandlerCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool HandlerCalled { get; set; }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        public class Handler : IHandleMessages<MyMessage>
+        {
+            readonly Context scenarioContext;
+
+            public Handler(Context scenarioContext)
+            {
+                this.scenarioContext = scenarioContext;
+            }
+
+            public Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                if (context.MessageHeaders[Headers.ReplyToAddress] == ReplyToValue)
+                {
+                    scenarioContext.HandlerCalled = true;
+                }
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
@@ -333,6 +333,7 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.6.1.2\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="Configuration\JsonExtensions.cs" />
     <Compile Include="Configuration\When_configuring_message_wrapper_serializer.cs" />
+    <Compile Include="Configuration\When_receiving_from_another_account_wo_aliases.cs" />
     <Compile Include="Configuration\When_sending_messages_with_mapped_account_names.cs" />
     <Compile Include="Configuration\When_configuring_account_names.cs" />
     <Compile Include="Configuration\When_sending_message_with_custom_reply_to.cs" />

--- a/src/Transport/Config/Extensions/AzureStorageAddressingSettings.cs
+++ b/src/Transport/Config/Extensions/AzureStorageAddressingSettings.cs
@@ -77,10 +77,13 @@
                     }
                     else
                     {
-                        // it must be a logical name, try to find it, otherwise throw
-                        if (aliasToConnectionStringMap.ContainsKey(address.StorageAccount) == false)
+                        if (useLogicalQueueAddresses)
                         {
-                            throw new KeyNotFoundException($"No account was mapped under following name '{address.StorageAccount}'. Please map it using AddStorageAccount method.");
+                            // it must be a logical name, try to find it, otherwise throw
+                            if (aliasToConnectionStringMap.ContainsKey(address.StorageAccount) == false)
+                            {
+                                throw new KeyNotFoundException($"No account was mapped under following name '{address.StorageAccount}'. Please map it using AddStorageAccount method.");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Because #193 required bumping up a lot of (beta) dependencies, porting it to `develop` causes a lot of conflicts. This PR provides an artificially created merge commit (`git commit-tree`) that merges back all the fixes.