### PR TITLE
Removed task tracking and replaced with spinning over concurrency limiter

### DIFF
--- a/src/Transport/MessagePump.cs
+++ b/src/Transport/MessagePump.cs
@@ -178,10 +178,10 @@
         SemaphoreSlim concurrencyLimiter;
 
         Task[] messagePumpTasks;
+        int maximumConcurrency;
         int? degreeOfReceiveParallelism;
         static ILog Logger = LogManager.GetLogger<MessagePump>();
         static TimeSpan StoppingAllTasksTimeout = TimeSpan.FromSeconds(30);
         static TimeSpan TimeToWaitBeforeTriggering = TimeSpan.FromSeconds(30);
-        int maximumConcurrency;
     }
 }


### PR DESCRIPTION
Replaces the task tracking approach for shutdown with a simpler spinning over the semaphore (concurrency limiter). It still preserves the timing out after 30 seconds as well as the shutdown semantics.