### PR TITLE
Bringing back the RC tagging for release branches

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,3 +3,5 @@ next-version: 7.0
 branches:
   develop:
     tag: alpha
+  release:
+    tag: rc


### PR DESCRIPTION
#219 removed the usage of GitVersion RC regex pattern. With GitVersion 4 the pattern has been changed and need to follow the following guidelines, see "Branch Configuration" on https://gitversion.readthedocs.io/en/latest/configuration/.

An example can be found 
See https://github.com/Particular/NServiceBus.RabbitMQ/blob/develop/GitVersion.yml