### PR TITLE
Timeout headers are encoded with UTF8 with length preambule

### DIFF
--- a/src/Tests/DelayDelivery/HeadersEncoderTests.cs
+++ b/src/Tests/DelayDelivery/HeadersEncoderTests.cs
@@ -1,0 +1,51 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues.AcceptanceTests.DelayDelivery
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using WindowsAzureStorageQueues.DelayDelivery;
+    using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
+
+    public class HeadersEncoderTests
+    {
+        [TestCaseSource(nameof(HeaderValues))]
+        public void Test(Dictionary<string, string> values)
+        {
+            var bytes = HeadersEncoder.Serialize(values);
+            var actual = HeadersEncoder.Deserialize(bytes);
+
+            CollectionAssert.AreEqual(values.OrderBy(kvp => kvp.Key), actual.OrderBy(kvp => kvp.Key), new KeyValuePairComparer());
+        }
+
+        static IEnumerable<ITestCaseData> HeaderValues()
+        {
+            yield return new TestCaseData(new Dictionary<string, string>()).SetName("Empty");
+            yield return new TestCaseData(new Dictionary<string, string> { { "test", "" } }).SetName("Empty value");
+            yield return new TestCaseData(new Dictionary<string, string> { { "k1", "v1" }, {"k2","v2"} }).SetName("Two values");
+
+            var key = new string('a',1024);
+            var value = new string('b',1024);
+
+            yield return new TestCaseData(new Dictionary<string, string>{{key, value}}).SetName("Very long keys and values");
+        }
+
+        class KeyValuePairComparer : IComparer
+        {
+            public int Compare(object x, object y)
+            {
+                var kvp1 = (KeyValuePair<string, string>)x;
+                var kvp2 = (KeyValuePair<string, string>)y;
+
+                var comparison = string.Compare(kvp1.Key, kvp2.Key, StringComparison.Ordinal);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                return string.Compare(kvp1.Value, kvp2.Value, StringComparison.Ordinal);
+            }
+        }
+    }
+}

--- a/src/Transport/DelayDelivery/HeadersEncoder.cs
+++ b/src/Transport/DelayDelivery/HeadersEncoder.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues.DelayDelivery
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.Serialization;
+    using System.Text;
+
+    class HeadersEncoder
+    {
+        const int IntSize = 4;
+        static readonly Encoding Encoding = new UTF8Encoding(false);
+
+        internal static byte[] Serialize(Dictionary<string, string> headers)
+        {
+            using (var ms = new MemoryStream())
+            {
+                foreach (var header in headers)
+                {
+                    WriteWithPositionPrefix(ms, header.Key);
+                    WriteWithPositionPrefix(ms, header.Value);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        static void WriteWithPositionPrefix(MemoryStream ms, string value)
+        {
+            var positionStart = ms.Position;
+
+            // skip 4 for end position
+            ms.Seek(IntSize, SeekOrigin.Current);
+
+            // write
+            var encoded = Encoding.GetBytes(value);
+            WriteAllBytes(ms, encoded);
+            var positionEnd = ms.Position;
+            var length = (int) (positionEnd - positionStart - IntSize);
+
+            // seek to start
+            ms.Seek(positionStart, SeekOrigin.Begin);
+            
+            // write end position
+            WriteAllBytes(ms, BitConverter.GetBytes(length));
+
+            // seek to end
+            ms.Seek(positionEnd, SeekOrigin.Begin);
+        }
+
+        // ReSharper disable once SuggestBaseTypeForParameter
+        static void WriteAllBytes(MemoryStream stream, byte[] bytes)
+        {
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        internal static Dictionary<string, string> Deserialize(byte[] bytes)
+        {
+            var result = new Dictionary<string, string>();
+            using (var ms = new MemoryStream(bytes))
+            {
+                var buffer = new byte[64];
+                while (ms.Position < ms.Length)
+                {
+                    var key = ReadString(ms, ref buffer);
+                    var value = ReadString(ms, ref buffer);
+
+                    result.Add(key,value);
+                }
+            }
+
+            return result;
+        }
+
+        // ReSharper disable once SuggestBaseTypeForParameter
+        static string ReadString(MemoryStream ms, ref byte[] buffer)
+        {
+            if (ms.Read(buffer, 0, IntSize) != IntSize)
+            {
+                throw new SerializationException();
+            }
+
+            var length = BitConverter.ToInt32(buffer, 0);
+            if (length > buffer.Length)
+            {
+                Array.Resize(ref buffer, length);
+            }
+
+            if (ms.Read(buffer, 0, length) != length)
+            {
+                throw new SerializationException();
+            }
+
+            return Encoding.GetString(buffer, 0, length);
+        }
+    }
+}


### PR DESCRIPTION
Connects to #220

This PR changes encoding of headers from JSON based to a custom UTF8 with length preamble.

A dummy performance test just to show that we are not that much slower than JSON. Bytes of course will be encoded when transmitted etc etc. This is just to remove JSON.NET dep and to have a small and efficient enough serializer.

|Serializer | Time to serialize 100000 dummy non-empty records |
|---|---|
|This custom binary serializer | 00:00:00.2466783 |
|JSON.NET | 00:00:00.5265303|