### PR TITLE
Moving develop back to 7.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 assembly-versioning-scheme: Major
-next-version: 8.0
+next-version: 7.0
 branches:
   develop:
     tag: alpha


### PR DESCRIPTION
This change moves `develop` back to 7.0. This will allow to ship Native Delayed Delivery in minor, reducing all the overhead connected with bumping up the major. After reviewing all the changes needed, I'd say that it's cost-wise to stay on minor for this one. Additionally, the rest of transports is also shipping as minor.