### PR TITLE
Native Delayed Delivery should be enabled only if opt-in

### DIFF
--- a/src/AcceptanceTests/Sending/When_TimeoutManager_disabled.cs
+++ b/src/AcceptanceTests/Sending/When_TimeoutManager_disabled.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AzureStorageQueues.AcceptanceTests.Sending
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Features;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using AcceptanceTesting.Customization;
+    using Configuration.AdvanceExtensibility;
+
+    public class When_TimeoutManager_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_startup_properly_and_send_regular_messages()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When((session, c) => session.Send(new MyMessage { Id = c.TestRunId })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.WasCalled)
+                .Run()
+                .ConfigureAwait(false);
+
+            Assert.True(context.WasCalled, "The message handler should be called");
+        }
+
+       
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(cfg =>
+                {
+                    cfg.UseTransport<AzureStorageQueueTransport>();
+                    cfg.DisableFeature<TimeoutManager>();
+                    cfg.ConfigureTransport().Routing()
+                        .RouteToEndpoint(typeof(MyMessage), typeof(Receiver));
+                });
+            }
+        }
+        
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(cfg =>
+                {
+                    cfg.UseTransport<AzureStorageQueueTransport>();
+                    cfg.DisableFeature<TimeoutManager>();
+                    
+                    // override delayed delivery settings, to make them unset
+                    cfg.GetSettings().Set<DelayedDeliverySettings>(new DelayedDeliverySettings());
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    if (TestContext.TestRunId != message.Id)
+                    {
+                        return Task.FromResult(0);
+                    }
+
+                    TestContext.WasCalled = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/AcceptanceTests/Sending/When_TimeoutManager_feature_disabled.cs
+++ b/src/AcceptanceTests/Sending/When_TimeoutManager_feature_disabled.cs
@@ -10,7 +10,7 @@
     using AcceptanceTesting.Customization;
     using Configuration.AdvanceExtensibility;
 
-    public class When_TimeoutManager_disabled : NServiceBusAcceptanceTest
+    public class When_TimeoutManager_feature_disabled : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_startup_properly_and_send_regular_messages()

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -48,7 +48,7 @@
                 yield return typeof(DiscardIfNotReceivedBefore);
                 yield return typeof(NonDurableDelivery);
 
-                if (delayedDelivery != null)
+                if (delayedDeliverySettings.TimeoutManagerDisabled)
                 {
                     yield return typeof(DoNotDeliverBefore);
                     yield return typeof(DelayDeliveryWith);

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -153,7 +153,8 @@
             }
             else
             {
-                shouldSend = (_, __) => Task.FromResult(true);
+                var trueTask = Task.FromResult(true);
+                shouldSend = (_, __) => trueTask;
             }
             return new Dispatcher(addressRetriever, addressing, serializer, shouldSend);
         }

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -10,7 +10,6 @@
     using DelayedDelivery;
     using Features;
     using Logging;
-    using NServiceBus.Config;
     using Performance.TimeToBeReceived;
     using Routing;
     using Serialization;

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -35,7 +35,7 @@
             }
 
             string tableName;
-            if (IsNativeDelayedDeliveryCongifured(out tableName))
+            if (IsNativeDelayedDeliveryConfigured(out tableName))
             {
                 delayedDelivery = new NativeDelayDelivery(connectionString, tableName);
             }
@@ -188,7 +188,7 @@
             var peekInterval = settings.Get<TimeSpan>(WellKnownConfigurationKeys.ReceiverPeekInterval);
 
             string tableName;
-            if (IsNativeDelayedDeliveryCongifured(out tableName))
+            if (IsNativeDelayedDeliveryConfigured(out tableName))
             {
                 nativeTimeoutsCancellationSource = new CancellationTokenSource();
                 poller = new TimeoutsPoller(connectionString, BuildDispatcher(), tableName, new BackoffStrategy(maximumWaitTime, peekInterval));
@@ -203,7 +203,7 @@
             return poller != null ? poller.Stop() : TaskEx.CompletedTask;
         }
 
-        bool IsNativeDelayedDeliveryCongifured(out string tableName)
+        bool IsNativeDelayedDeliveryConfigured(out string tableName)
         {
             if (string.IsNullOrEmpty(delayedDeliverySettings.Name))
             {

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -9,6 +9,8 @@
     using Config;
     using DelayedDelivery;
     using Features;
+    using Logging;
+    using NServiceBus.Config;
     using Performance.TimeToBeReceived;
     using Routing;
     using Serialization;
@@ -32,7 +34,6 @@
             {
                 // user configured delayed delivery. Even when TimeoutManager was not disabled via DD but using the feature, we'll disable it for user
                 // TM is automatically disabled to do not throw during check
-
                 delayedDeliverySettings?.DisableTimeoutManager();
             }
 
@@ -197,6 +198,10 @@
                 await poller.Start(settings, nativeTimeoutsCancellationSource.Token).ConfigureAwait(false);
                 await delayedDelivery.Init().ConfigureAwait(false);
             }
+            else
+            {
+                Log.Warn($"This transport doesn't have native delayed delivery enabled. To enable it, use '{nameof(AzureStorageTransportExtensions.DelayedDelivery)}' when configuring ASQ transport.");
+            }
         }
 
         public override Task Stop()
@@ -224,5 +229,6 @@
         NativeDelayDelivery delayedDelivery;
         TimeoutsPoller poller;
         CancellationTokenSource nativeTimeoutsCancellationSource;
+        static readonly ILog Log = LogManager.GetLogger<AzureStorageQueueInfrastructure>();
     }
 }

--- a/src/Transport/DelayDelivery/NativeDelayDelivery.cs
+++ b/src/Transport/DelayDelivery/NativeDelayDelivery.cs
@@ -6,11 +6,9 @@
     using System.Threading.Tasks;
     using DelayedDelivery;
     using DeliveryConstraints;
-    using Features;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
     using Performance.TimeToBeReceived;
-    using Settings;
     using Transport;
 
     class NativeDelayDelivery
@@ -55,27 +53,6 @@
         }
 
         public static DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
-
-        public static StartupCheckResult CheckForInvalidSettings(ReadOnlySettings settings)
-        {
-            var externalTimeoutManagerAddress = settings.GetOrDefault<string>("NServiceBus.ExternalTimeoutManagerAddress") != null;
-            var timeoutManagerFeatureActive = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Active;
-            var timeoutManagerDisabled = (settings.GetOrDefault<DelayedDeliverySettings>()?.TimeoutManagerDisabled).GetValueOrDefault(false);
-            
-            if (externalTimeoutManagerAddress)
-            {
-                return StartupCheckResult.Failed("An external timeout manager address cannot be configured because the timeout manager is not being used for delayed delivery.");
-            }
-
-            if (!timeoutManagerDisabled && !timeoutManagerFeatureActive)
-            {
-                return StartupCheckResult.Failed(
-                    "The timeout manager is not active, but the transport has not been properly configured for this. " +
-                                                 "Use 'EndpointConfiguration.UseTransport<AzureStorageQueueTransport>().DelayedDelivery().DisableTimeoutManager()' to ensure delayed messages can be sent properly.");
-            }
-            
-            return StartupCheckResult.Success;
-        }
 
         static TimeSpan? GetVisbilityDelay(List<DeliveryConstraint> constraints)
         {


### PR DESCRIPTION
Connects to #230 

This PR introduces both:
- a failing test for a scenario with a disabled `TimeoutManager` and failing endpoint
- fix for proper management of native delayed delivery in ASQ