### PR TITLE
[WIP] Hotfix 7.4.1

### DIFF
--- a/src/Transport/AzureMessageQueueReceiver.cs
+++ b/src/Transport/AzureMessageQueueReceiver.cs
@@ -8,12 +8,11 @@ namespace NServiceBus.AzureStorageQueues
 
     class AzureMessageQueueReceiver
     {
-        public AzureMessageQueueReceiver(IMessageEnvelopeUnwrapper unwrapper, CloudQueueClient client, QueueAddressGenerator addressGenerator, BackoffStrategy backoffStrategy)
+        public AzureMessageQueueReceiver(IMessageEnvelopeUnwrapper unwrapper, CloudQueueClient client, QueueAddressGenerator addressGenerator)
         {
             this.unwrapper = unwrapper;
             this.client = client;
             this.addressGenerator = addressGenerator;
-            this.backoffStrategy = backoffStrategy;
         }
 
         /// <summary>
@@ -51,7 +50,7 @@ namespace NServiceBus.AzureStorageQueues
             return queue;
         }
 
-        internal async Task<List<MessageRetrieved>> Receive(CancellationToken token)
+        internal async Task<List<MessageRetrieved>> Receive(BackoffStrategy backoffStrategy, CancellationToken token)
         {
             var rawMessages = await inputQueue.GetMessagesAsync(BatchSize, MessageInvisibleTime, null, null, token).ConfigureAwait(false);
 
@@ -79,7 +78,6 @@ namespace NServiceBus.AzureStorageQueues
         CloudQueue inputQueue;
         CloudQueue errorQueue;
         CloudQueueClient client;
-        readonly BackoffStrategy backoffStrategy;
 
         public string QueueName => inputQueue.Name;
 

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -92,7 +92,7 @@
                     var maximumWaitTime = settings.Get<TimeSpan>(WellKnownConfigurationKeys.ReceiverMaximumWaitTimeWhenIdle);
                     var peekInterval = settings.Get<TimeSpan>(WellKnownConfigurationKeys.ReceiverPeekInterval);
 
-                    var receiver = new AzureMessageQueueReceiver(unwrapper, client, addressGenerator, new BackoffStrategy(maximumWaitTime, peekInterval))
+                    var receiver = new AzureMessageQueueReceiver(unwrapper, client, addressGenerator)
                     {
                         MessageInvisibleTime = settings.Get<TimeSpan>(WellKnownConfigurationKeys.ReceiverMessageInvisibleTime),
 
@@ -106,7 +106,7 @@
                         degreeOfReceiveParallelism = parallelism;
                     }
 
-                    return new MessagePump(receiver, addressing, degreeOfReceiveParallelism);
+                    return new MessagePump(receiver, addressing, degreeOfReceiveParallelism, maximumWaitTime, peekInterval);
                 },
                 () => new AzureMessageQueueCreator(client, GetAddressGenerator(settings)),
                 () => Task.FromResult(StartupCheckResult.Success)

--- a/src/Transport/BackoffStrategy.cs
+++ b/src/Transport/BackoffStrategy.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.AzureStorageQueues
         readonly TimeSpan peekInterval;
         readonly TimeSpan maximumWaitTimeWhenIdle;
 
-        TimeSpan timeToDelayNextPeek;
+        TimeSpan timeToDelayUntilNextPeek;
         
         /// <summary>
         /// </summary>
@@ -23,21 +23,21 @@ namespace NServiceBus.AzureStorageQueues
 
         void OnSomethingProcessed()
         {
-            timeToDelayNextPeek = TimeSpan.Zero;
+            timeToDelayUntilNextPeek = TimeSpan.Zero;
         }
 
         Task OnNothingProcessed(CancellationToken token)
         {
-            if (timeToDelayNextPeek + peekInterval < maximumWaitTimeWhenIdle)
+            if (timeToDelayUntilNextPeek + peekInterval < maximumWaitTimeWhenIdle)
             {
-                timeToDelayNextPeek += peekInterval;
+                timeToDelayUntilNextPeek += peekInterval;
             }
             else
             {
-                timeToDelayNextPeek = maximumWaitTimeWhenIdle;
+                timeToDelayUntilNextPeek = maximumWaitTimeWhenIdle;
             }
 
-            return Task.Delay(timeToDelayNextPeek, token);
+            return Task.Delay(timeToDelayUntilNextPeek, token);
         }
 
         public Task OnBatch(int receivedBatchSize, CancellationToken token)


### PR DESCRIPTION
Fixes #241

Before the backup strategy was introduced the receiver used by the pump in parallel was designed to be stateless. By introducing the backup strategy in the constructor the receiver became stateful since the backup strategy has a field that needs to be updated. Before this change multiple parallel receive loops will try to update the same backup strategy and read/update the same field concurrently.

We decided against making the retriever per receive loop and just float in the backup strategy into the receiver to make it stateless again.