### PR TITLE
Allow delayed delivery polling to be disabled

### DIFF
--- a/src/AcceptanceTests/Sending/When_deferring_a_message_natively_and_delayed_delivery_is_disabled.cs
+++ b/src/AcceptanceTests/Sending/When_deferring_a_message_natively_and_delayed_delivery_is_disabled.cs
@@ -1,0 +1,82 @@
+﻿namespace NServiceBus.AzureStorageQueues.AcceptanceTests.Sending
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_deferring_a_message_natively_and_delayed_delivery_is_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_throw()
+        {
+            try
+            {
+                var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.When((session, ctx) =>
+                    {
+                        var delay = TimeSpan.FromSeconds(2);
+
+                        var options = new SendOptions();
+
+                        options.DelayDeliveryWith(delay);
+                        options.RouteToThisEndpoint();
+
+                        try
+                        {
+                            return session.Send(new MyMessage(), options);
+                        }
+                        catch (Exception exception)
+                        {
+                            ctx.SendException = exception;
+                            return Task.FromResult(0);
+                        }
+                    }))
+                    .Done(ctx => ctx.WasCalled)
+                    .Run();
+
+                Assert.IsFalse(context.WasCalled, "Endpoint's handler should never be invoked.");
+            }
+            catch (Exception exception)
+            {
+                Assert.True(exception.Message.Contains("Cannot delay delivery of messages when TimeoutManager is disabled or there is no infrastructure support for delayed messages"));
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public Exception SendException { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    var delayedDelivery = config.UseTransport<AzureStorageQueueTransport>().DelayedDelivery();
+                    delayedDelivery.DisableTimeoutManager();
+                    delayedDelivery.DisableDelayedDelivery();
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    Context.WasCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/AcceptanceTests/Sending/When_delaying_messages_and_delayed_delivery_is_disabled.cs
+++ b/src/AcceptanceTests/Sending/When_delaying_messages_and_delayed_delivery_is_disabled.cs
@@ -24,17 +24,9 @@
                         options.DelayDeliveryWith(delay);
                         options.RouteToThisEndpoint();
 
-                        try
-                        {
-                            return session.Send(new MyMessage(), options);
-                        }
-                        catch (Exception exception)
-                        {
-                            ctx.SendException = exception;
-                            return Task.FromResult(0);
-                        }
+                        return session.Send(new MyMessage(), options);
                     }))
-                    .Done(ctx => ctx.WasCalled)
+                    .Done(ctx => true)
                     .Run();
 
                 Assert.IsFalse(context.WasCalled, "Endpoint's handler should never be invoked.");

--- a/src/AcceptanceTests/Sending/When_delaying_messages_and_delayed_delivery_is_disabled.cs
+++ b/src/AcceptanceTests/Sending/When_delaying_messages_and_delayed_delivery_is_disabled.cs
@@ -7,7 +7,7 @@
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
-    public class When_deferring_a_message_natively_and_delayed_delivery_is_disabled : NServiceBusAcceptanceTest
+    public class When_delaying_messages_and_delayed_delivery_is_disabled : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_throw()

--- a/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
+++ b/src/Tests/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
@@ -37,9 +37,9 @@ namespace NServiceBus
         [System.ObsoleteAttribute(@"Azure Storage Queues transport is no longer shortening queue names and requires sanitization algorithm to be provided using configuration API. Use `transport.SanitizeQueueNamesWith(Func<string, string>)` instead. The member currently throws a NotImplementedException. Will be removed in version 9.0.0.", true)]
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseSha1ForShortening(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config) { }
     }
-    public class DelayedDeliverySettings
+    public class DelayedDeliverySettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
-        public DelayedDeliverySettings() { }
+        public void DisableDelayedDelivery() { }
         public void DisableTimeoutManager() { }
         public void UseTableName(string delayedMessagesTableName) { }
     }

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -40,7 +40,7 @@
         static string GetDelayedDeliveryTableName(SettingsHolder settings)
         {
             var delayedDeliveryTableName = settings.GetOrDefault<string>(WellKnownConfigurationKeys.DelayedDelivery.TableName);
-            var delayedDeliveryTableNameWasNotOverridden = settings.HasExplicitValue(WellKnownConfigurationKeys.DelayedDelivery.TableName);
+            var delayedDeliveryTableNameWasNotOverridden = string.IsNullOrEmpty(delayedDeliveryTableName);
 
             if (delayedDeliveryTableNameWasNotOverridden)
             {
@@ -61,7 +61,7 @@
             }
 
             var hashName = BitConverter.ToString(hashedName).Replace("-", string.Empty);
-            return "delays" + hashName;
+            return "delays" + hashName.ToLower();
         }
 
         public override IEnumerable<Type> DeliveryConstraints

--- a/src/Transport/Config/AzureStorageTransportExtensions.cs
+++ b/src/Transport/Config/AzureStorageTransportExtensions.cs
@@ -131,7 +131,7 @@ namespace NServiceBus
         /// </summary>
         public static DelayedDeliverySettings DelayedDelivery(this TransportExtensions<AzureStorageQueueTransport> config)
         {
-            return config.GetSettings().GetOrCreate<DelayedDeliverySettings>();
+            return new DelayedDeliverySettings(config.GetSettings());
         }
 
         internal const int MaxDegreeOfReceiveParallelism = 32;

--- a/src/Transport/Config/DelayedDeliverySettings.cs
+++ b/src/Transport/Config/DelayedDeliverySettings.cs
@@ -2,16 +2,15 @@ namespace NServiceBus
 {
     using System;
     using System.Text.RegularExpressions;
+    using AzureStorageQueues.Config;
+    using Configuration.AdvancedExtensibility;
+    using Features;
+    using Settings;
 
     /// <summary>Configures native delayed delivery.</summary>
-    public class DelayedDeliverySettings
+    public class DelayedDeliverySettings : ExposeSettings
     {
-        internal string TableName;
-        internal bool TimeoutManagerDisabled;
-
-        internal bool TableNameWasNotOverridden => string.IsNullOrEmpty(TableName);
-
-        static Regex tableNameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9]{2,62}$", RegexOptions.Compiled);
+        internal DelayedDeliverySettings(SettingsHolder settings) : base(settings) { }
 
         /// <summary>Override the default table name used for storing delayed messages.</summary>
         /// <param name="delayedMessagesTableName">New table name.</param>
@@ -20,17 +19,37 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(delayedMessagesTableName), delayedMessagesTableName);
 
             if (tableNameRegex.IsMatch(delayedMessagesTableName) == false)
-            {
                 throw new ArgumentException($"{nameof(delayedMessagesTableName)} must match the following regular expression '{tableNameRegex}'");
-            }
 
-            TableName = delayedMessagesTableName.ToLower();
+            this.GetSettings().Set(WellKnownConfigurationKeys.DelayedDelivery.TableName, delayedMessagesTableName.ToLower());
         }
 
-        /// <summary>Disables the Timeout Manager for the endpoint. Before disabling ensure there all timeouts in the timeout store have been processed or migrated.</summary>
+        /// <summary>
+        /// Disables the Timeout Manager for the endpoint. Before disabling ensure there all timeouts in the timeout store
+        /// have been processed or migrated.
+        /// </summary>
         public void DisableTimeoutManager()
         {
-            TimeoutManagerDisabled = true;
+            this.GetSettings().Set(WellKnownConfigurationKeys.DelayedDelivery.DisableTimeoutManager, true);
         }
+
+        /// <summary>
+        /// Disable delayed delivery.
+        /// <remarks>
+        /// Disabling delayed delivery reduces costs associated with polling Azure Storage service for delayed messages that need
+        /// to be dispatched.
+        /// Do not use this setting if your endpoint required delayed messages, timeouts, or delayed retries.
+        /// </remarks>
+        /// </summary>
+        public void DisableDelayedDelivery()
+        {
+            // disable delayed delivery
+            this.GetSettings().Set(WellKnownConfigurationKeys.DelayedDelivery.DisableDelayedDelivery, true);
+
+            // disable timeout manager
+            this.GetSettings().Set(typeof(TimeoutManager).FullName, FeatureState.Disabled);
+        }
+
+        static readonly Regex tableNameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9]{2,62}$", RegexOptions.Compiled);
     }
 }

--- a/src/Transport/Config/WellKnownConfigurationKeys.cs
+++ b/src/Transport/Config/WellKnownConfigurationKeys.cs
@@ -11,5 +11,12 @@
         public const string DegreeOfReceiveParallelism = "Transport.AzureStorageQueue.DegreeOfReceiveParallelism";
         public const string UseAccountNamesInsteadOfConnectionStrings = "Transport.AzureStorageQueue.UseAccountAliasesInsteadOfConnectionStrings";
         public const string QueueSanitizer = "Transport.AzureStorageQueue.QueueSanitizer";
+
+        public static class DelayedDelivery
+        {
+            public const string TableName = "Transport.AzureStorageQueue.TableName";
+            public const string DisableTimeoutManager = "Transport.AzureStorageQueue.DisableTimeoutManager";
+            public const string DisableDelayedDelivery = "Transport.AzureStorageQueue.DisableDelayedDelivery";
+        }
     }
 }

--- a/src/Transport/DelayDelivery/NativeDelayDelivery.cs
+++ b/src/Transport/DelayDelivery/NativeDelayDelivery.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using AzureStorageQueues.Config;
     using DelayedDelivery;
     using DeliveryConstraints;
     using Features;
@@ -59,7 +60,7 @@
         {
             var externalTimeoutManagerAddress = settings.GetOrDefault<string>("NServiceBus.ExternalTimeoutManagerAddress") != null;
             var timeoutManagerFeatureActive = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Active;
-            var timeoutManagerDisabled = settings.Get<DelayedDeliverySettings>().TimeoutManagerDisabled;
+            var timeoutManagerDisabled = settings.Get<bool>(WellKnownConfigurationKeys.DelayedDelivery.DisableTimeoutManager);
 
             if (externalTimeoutManagerAddress)
             {
@@ -69,8 +70,8 @@
             if (!timeoutManagerDisabled && !timeoutManagerFeatureActive)
             {
                 return StartupCheckResult.Failed(
-                    "The timeout manager is not active, but the transport has not been properly configured for this. " +
-                                                 "Use 'EndpointConfiguration.UseTransport<AzureStorageQueueTransport>().DelayedDelivery().DisableTimeoutManager()' to ensure delayed messages can be sent properly.");
+                    "The timeout manager is not active, but the transport has not been properly configured for this. "
+                    + "Use 'EndpointConfiguration.UseTransport<AzureStorageQueueTransport>().DelayedDelivery().DisableTimeoutManager()' to ensure delayed messages can be sent properly.");
             }
 
             return StartupCheckResult.Success;


### PR DESCRIPTION
Connects to #250 
Fixes #250 

Prevent unnecessary Storage polling when an endpoint doesn't require features based on delayed delivery.