### PR TITLE
Stamping all outgoing messages to also catch delayed delivery

### DIFF
--- a/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
+++ b/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
@@ -64,6 +64,7 @@ public class ConfigureEndpointAzureStorageQueueTransport : IConfigureEndpointTes
         configuration.UseSerialization<XmlSerializer>();
 
         configuration.Pipeline.Register("test-independence-skip", typeof(TestIndependence.SkipBehavior), "Skips messages from other runs");
+        configuration.Pipeline.Register("test-independence-stamp", typeof(TestIndependence.StampOutgoingBehavior), "Stamps outgoing messages from this run");
         transportConfig.SerializeMessageWrapperWith<TestIndependence.TestIdAppendingSerializationDefinition<NewtonsoftSerializer>>();
 
         return Task.FromResult(0);


### PR DESCRIPTION
This solves the issue of delayed messages with native delayed delivery not being stamped properly and then leaking over to other test runs. 