### PR TITLE
Guard against sub second ttbr

### DIFF
--- a/src/Transport/Dispatcher.cs
+++ b/src/Transport/Dispatcher.cs
@@ -85,6 +85,17 @@
                 throw new InvalidOperationException($"TimeToBeReceived is set to more than 7 days (maximum for Azure Storage queue) for message type '{messageType}'.");
             }
 
+            if (timeToBeReceived.HasValue)
+            {
+                var seconds = Convert.ToInt64(Math.Ceiling(timeToBeReceived.Value.TotalSeconds));
+
+                if (seconds < 0)
+                {
+                    throw new Exception($"Message cannot be sent with a delay less than 1 second. Provided delay was {timeToBeReceived.Value.TotalMilliseconds} mSec.");
+                }
+                timeToBeReceived = TimeSpan.FromSeconds(seconds);
+            }
+
             var wrapper = BuildMessageWrapper(operation, queue);
             await Send(wrapper, sendQueue, timeToBeReceived).ConfigureAwait(false);
         }
@@ -101,6 +112,7 @@
                 rawMessage = CloudQueueMessage.CreateCloudQueueMessageFromByteArray(stream.ToArray());
 #endif
             }
+
             return sendQueue.AddMessageAsync(rawMessage, timeToBeReceived, null, null, null);
         }
 

--- a/src/Transport/Dispatcher.cs
+++ b/src/Transport/Dispatcher.cs
@@ -91,7 +91,7 @@
 
                 if (seconds < 0)
                 {
-                    throw new Exception($"Message cannot be sent with a delay less than 1 second. Provided delay was {timeToBeReceived.Value.TotalMilliseconds} mSec.");
+                    throw new Exception($"Message cannot be sent with a delay less than 1 second. Provided delay was {timeToBeReceived.Value.TotalMilliseconds} ms.");
                 }
                 timeToBeReceived = TimeSpan.FromSeconds(seconds);
             }

--- a/src/Transport/Dispatcher.cs
+++ b/src/Transport/Dispatcher.cs
@@ -89,9 +89,9 @@
             {
                 var seconds = Convert.ToInt64(Math.Ceiling(timeToBeReceived.Value.TotalSeconds));
 
-                if (seconds < 0)
+                if (seconds <= 0)
                 {
-                    throw new Exception($"Message cannot be sent with a delay less than 1 second. Provided delay was {timeToBeReceived.Value.TotalMilliseconds} ms.");
+                    throw new Exception($"Message cannot be sent with a provided delay of {timeToBeReceived.Value.TotalMilliseconds} ms.");
                 }
                 timeToBeReceived = TimeSpan.FromSeconds(seconds);
             }


### PR DESCRIPTION
Connects to #269 
Fixes to #269 
Related to https://github.com/Particular/NServiceBus.Persistence.AzureStorage/pull/167

Guard against bug in ASQ client library https://github.com/Azure/azure-storage-net/issues/540 by converting any sub-second TTBR to one second.

@Particular/azure-maintainers please review