### PR TITLE
Re-enable ignored tests

### DIFF
--- a/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
+++ b/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
@@ -5,8 +5,6 @@ using NServiceBus.AcceptanceTesting.Support;
 using NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions;
 using NUnit.Framework;
 using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
-using NServiceBus.AcceptanceTests.Routing;
-using NServiceBus.AcceptanceTests.Versioning;
 
 public class ConfigureEndpointAzureStorageQueueTransport : IConfigureEndpointTestExecution
 {
@@ -38,21 +36,6 @@ public class ConfigureEndpointAzureStorageQueueTransport : IConfigureEndpointTes
         if (endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_unsubscribing_from_event.Publisher))))
         {
             Assert.Ignore("Ignored until issue #173 is resolved.");
-        }
-
-        // see https://github.com/Particular/NServiceBus/pull/4956
-        if (endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_base_event_from_2_publishers.Publisher1))) ||
-            endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_extending_command_routing.Receiver))) ||
-            endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_publishing.Publisher))) ||
-            endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_publishing.Publisher3))) ||
-            endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_publishing_an_event_implementing_two_unrelated_interfaces.Publisher))) ||
-            endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_publishing_an_interface.Publisher))) ||
-            endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_publishing_an_interface_with_unobtrusive.Publisher))) ||
-            endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_publishing_using_base_type.Publisher))) ||
-            endpointName.StartsWith(Conventions.EndpointNamingConvention(typeof(When_multiple_versions_of_a_message_is_published.V2Publisher)))
-            )
-        {
-            Assert.Ignore("Ignored until there is a case-insensitive way to discover a subscription.");
         }
  
         if (endpointName.StartsWith("RegisteringAdditionalDeserializers.CustomSerializationSender"))


### PR DESCRIPTION
Since the core beta is internally released that contains https://github.com/Particular/NServiceBus/pull/4956 we should re-enable those tests that were previously ignored