### PR TITLE
ToTransportAddress uses dash instead of dot for qualifier

### DIFF
--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -183,7 +183,7 @@
 
             if (logicalAddress.Qualifier != null)
             {
-                queue.Append("." + logicalAddress.Qualifier);
+                queue.Append("-" + logicalAddress.Qualifier);
             }
 
             return addressGenerator.GetQueueName(queue.ToString());


### PR DESCRIPTION
Addresses #279 