### PR TITLE
Refactoring tests with second namespace

### DIFF
--- a/src/AcceptanceTests/Configuration/When_configuring_account_names.cs
+++ b/src/AcceptanceTests/Configuration/When_configuring_account_names.cs
@@ -11,7 +11,7 @@
         public When_configuring_account_names()
         {
             connectionString = Testing.Utillities.GetEnvConfiguredConnectionString();
-            anotherConnectionString = Testing.Utillities.BuildAnotherConnectionString();
+            anotherConnectionString = Testing.Utillities.GetEnvConfiguredConnectionString2();
         }
 
         [Test]

--- a/src/AcceptanceTests/Configuration/When_configuring_account_names.cs
+++ b/src/AcceptanceTests/Configuration/When_configuring_account_names.cs
@@ -11,7 +11,7 @@
         public When_configuring_account_names()
         {
             connectionString = Testing.Utillities.GetEnvConfiguredConnectionString();
-            anotherConnectionString = Testing.Utillities.BuildAnotherConnectionString(connectionString);
+            anotherConnectionString = Testing.Utillities.BuildAnotherConnectionString();
         }
 
         [Test]

--- a/src/AcceptanceTests/Configuration/When_sending_message_with_custom_reply_to.cs
+++ b/src/AcceptanceTests/Configuration/When_sending_message_with_custom_reply_to.cs
@@ -18,36 +18,28 @@ namespace NServiceBus.AcceptanceTests.WindowsAzureStorageQueues.Configuration
         static When_sending_message_with_custom_reply_to()
         {
             connectionString = Testing.Utillities.GetEnvConfiguredConnectionString();
-            anotherConnectionString = Testing.Utillities.BuildAnotherConnectionString(connectionString);
+            anotherConnectionString = ConfigureEndpointAzureStorageQueueTransport.AnotherConnectionString;
             RawReplyTo = "q@" + anotherConnectionString;
         }
 
-        public When_sending_message_with_custom_reply_to()
+        [TestCaseSource(nameof(GetTestCases))]
+        public async Task Should_preserve_fully_qualified_name_when_using_mappings(string destination, string replyTo, string auditConnectionString)
         {
-            var account = CloudStorageAccount.Parse(connectionString);
-            auditQueue = account.CreateCloudQueueClient().GetQueueReference(AuditName);
-        }
-
-        [OneTimeSetUp]
-        public Task OneTimeSetup()
-        {
-            return auditQueue.CreateIfNotExistsAsync();
+            await Run<SenderUsingNamesInsteadOfConnectionStrings>(destination, replyTo, auditConnectionString).ConfigureAwait(false);
         }
 
         [TestCaseSource(nameof(GetTestCases))]
-        public async Task Should_preserve_fully_qualified_name_when_using_mappings(string destination, string replyTo)
+        public async Task Should_preserve_fully_qualified_name_when_using_raw_connection_strings(string destination, string replyTo, string auditConnectionString)
         {
-            await Run<SenderUsingNamesInsteadOfConnectionStrings>(destination, replyTo).ConfigureAwait(false);
+            await Run<SenderNotUsingNamesInsteadOfConnectionStrings>(destination, replyTo, auditConnectionString).ConfigureAwait(false);
         }
 
-        [TestCaseSource(nameof(GetTestCases))]
-        public async Task Should_preserve_fully_qualified_name_when_using_raw_connection_strings(string destination, string replyTo)
+        async Task Run<TSender>(string destination, string replyTo, string auditConnectionString) where TSender : Sender
         {
-            await Run<SenderNotUsingNamesInsteadOfConnectionStrings>(destination, replyTo).ConfigureAwait(false);
-        }
+            var account = CloudStorageAccount.Parse(auditConnectionString);
+            var auditQueue = account.CreateCloudQueueClient().GetQueueReference(AuditName);
+            await auditQueue.CreateIfNotExistsAsync();
 
-        async Task Run<TSender>(string destination, string replyTo) where TSender : Sender
-        {
             await Scenario.Define<Context>()
                 .WithEndpoint<TSender>(b => b.When(async s => { await Send(s, replyTo, destination).ConfigureAwait(false); }))
                 .Done(c => true)
@@ -74,10 +66,10 @@ namespace NServiceBus.AcceptanceTests.WindowsAzureStorageQueues.Configuration
         static IEnumerable<ITestCaseData> GetTestCases()
         {
             // combinatorial
-            yield return new TestCaseData(AuditName, RawReplyTo);
-            yield return new TestCaseData(AuditName, MappedReplyTo);
-            yield return new TestCaseData(AuditNameAtAnotherAccount, RawReplyTo);
-            yield return new TestCaseData(AuditNameAtAnotherAccount, MappedReplyTo);
+            yield return new TestCaseData(AuditName, RawReplyTo, connectionString);
+            yield return new TestCaseData(AuditName, MappedReplyTo, connectionString);
+            yield return new TestCaseData(AuditNameAtAnotherAccount, RawReplyTo, anotherConnectionString);
+            yield return new TestCaseData(AuditNameAtAnotherAccount, MappedReplyTo, anotherConnectionString);
         }
 
         static async Task Send(IMessageSession s, string replyTo, string destination)
@@ -88,7 +80,6 @@ namespace NServiceBus.AcceptanceTests.WindowsAzureStorageQueues.Configuration
             await s.Send(new MyCommand(), o).ConfigureAwait(false);
         }
 
-        readonly CloudQueue auditQueue;
         const string AuditName = "custom-reply-to-destination";
         const string AuditNameAtAnotherAccount = AuditName + "@" + AnotherConnectionStringName;
         const string DefaultConnectionStringName = "default_account";

--- a/src/AcceptanceTests/Configuration/When_sending_to_another_account_wo_aliases.cs
+++ b/src/AcceptanceTests/Configuration/When_sending_to_another_account_wo_aliases.cs
@@ -13,9 +13,8 @@ namespace NServiceBus.AcceptanceTests.WindowsAzureStorageQueues.Configuration
         public async Task Should_properly_handle_it()
         {
             var queue = Conventions.EndpointNamingConvention(typeof(Receiver));
-            var connectionString = Testing.Utillities.GetEnvConfiguredConnectionString();
 
-            var another = Testing.Utillities.BuildAnotherConnectionString(connectionString);
+            var another = ConfigureEndpointAzureStorageQueueTransport.AnotherConnectionString;
             var queueAddress = queue + "@" + another;
             
             var context = await Scenario.Define<Context>()
@@ -38,7 +37,11 @@ namespace NServiceBus.AcceptanceTests.WindowsAzureStorageQueues.Configuration
         {
             public Receiver()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>(configuration =>
+                {
+                    configuration.UseTransport<AzureStorageQueueTransport>()
+                        .ConnectionString(ConfigureEndpointAzureStorageQueueTransport.AnotherConnectionString);
+                });
             }
         }
 

--- a/src/AcceptanceTests/Utils.cs
+++ b/src/AcceptanceTests/Utils.cs
@@ -34,11 +34,5 @@
             var candidate = Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.User);
             return string.IsNullOrWhiteSpace(candidate) ? Environment.GetEnvironmentVariable(variable) : candidate;
         }
-
-        public static string BuildAnotherConnectionString()
-        {
-            return GetEnvConfiguredConnectionString2();
-        }
     }
-
 }

--- a/src/AcceptanceTests/Utils.cs
+++ b/src/AcceptanceTests/Utils.cs
@@ -35,9 +35,9 @@
             return string.IsNullOrWhiteSpace(candidate) ? Environment.GetEnvironmentVariable(variable) : candidate;
         }
 
-        public static string BuildAnotherConnectionString(string connectionString)
+        public static string BuildAnotherConnectionString()
         {
-            return connectionString + ";BlobEndpoint=https://notusedatall.blob.core.windows.net";
+            return GetEnvConfiguredConnectionString2();
         }
     }
 


### PR DESCRIPTION
Connects to #276 

These tests were using a spoofed 2nd account. Now they use two separate accounts.

@danielmarbach the tests I didn't like are `When_sending_messages_with_mapped_account_names` and `When_sending_message_with_custom_reply_to`. IMO they are unnecessarily complex and mix multiple concerns. We don't have to refactor them right now, but probably should address it at some point. For example, I could probably refactor `When_sending_messages_with_mapped_account_names` to use an "audit spy" endpoint to remove the complexity of native dequing and JSON parsing. If it's worth it, I'll go ahead and make the change.