### PR TITLE
Release 7.5.0

### DIFF
--- a/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
+++ b/src/AcceptanceTests/ConfigureAzureStorageQueueTransport.cs
@@ -11,7 +11,7 @@ using NServiceBus.AcceptanceTests.Versioning;
 
 public class ConfigureEndpointAzureStorageQueueTransport : IConfigureEndpointTestExecution
 {
-    internal static string ConnectionString => EnvironmentHelper.GetEnvironmentVariable($"{nameof(AzureStorageQueueTransport)}.ConnectionString") ?? "UseDevelopmentStorage=true";
+    internal static string ConnectionString => EnvironmentHelper.GetEnvironmentVariable($"{nameof(AzureStorageQueueTransport)}_ConnectionString") ?? "UseDevelopmentStorage=true";
 
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {

--- a/src/AcceptanceTests/Sending/When_delaying_messages_natively_in_hybrid_mode.cs
+++ b/src/AcceptanceTests/Sending/When_delaying_messages_natively_in_hybrid_mode.cs
@@ -1,0 +1,110 @@
+﻿namespace NServiceBus.Azure.Transports.WindowsAzureStorageQueues.AcceptanceTests.Sending
+{
+    using System;
+    using System.Diagnostics;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Configuration.AdvanceExtensibility;
+    using Features;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Table;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_delaying_messages_natively_in_hybrid_mode : NServiceBusAcceptanceTest
+    {
+        CloudTable delayedMessagesTable;
+
+        [SetUp]
+        public new async Task SetUp()
+        {
+            delayedMessagesTable = CloudStorageAccount.Parse(Utils.GetEnvConfiguredConnectionString()).CreateCloudTableClient().GetTableReference(SenderDelayedMessagesTable);
+            var tableExists = await delayedMessagesTable.ExistsAsync().ConfigureAwait(false);
+            if (tableExists)
+            {
+                foreach (var dte in await delayedMessagesTable.ExecuteQuerySegmentedAsync(new TableQuery(), null).ConfigureAwait(false))
+                {
+                    await delayedMessagesTable.ExecuteAsync(TableOperation.Delete(dte)).ConfigureAwait(false);
+                }
+            }
+        }
+
+        [Test]
+        public async Task Should_receive_the_message_after_delay()
+        {
+            var delay = TimeSpan.FromSeconds(10);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When((session, c) =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.DelayDeliveryWith(delay);
+                    c.Stopwatch = Stopwatch.StartNew();
+                    sendOptions.RouteToThisEndpoint();
+                    return session.Send(new MyMessage { Id = c.TestRunId }, sendOptions);
+                }))
+                .Done(c => c.WasCalled)
+                .Run(delay + TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+
+            Assert.True(context.WasCalled, "The message handler should be called");
+            Assert.Greater(context.Stopwatch.Elapsed, delay);
+        }
+
+       
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public Stopwatch Stopwatch { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(cfg =>
+                {
+                    var transport = cfg.UseTransport<AzureStorageQueueTransport>();
+
+                    var delayedDeliverySettings = transport.DelayedDelivery();
+                    delayedDeliverySettings.UseTableName(SenderDelayedMessagesTable);
+                    
+                    // run in hybrid mode, i.e. timeout manager and native delayed delivery need to be enabled
+                    // delayedDeliverySettings.DisableTimeoutManager(); is invoked by IConfigureEndpointTestExecution - need to undo it to allow hybrid mode
+                    var fieldInfo = typeof(DelayedDeliverySettings).GetField("TimeoutManagerDisabled", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    fieldInfo.SetValue(delayedDeliverySettings, false);
+                    // re-enable timeout manager back again
+                    transport.GetSettings().Set(typeof(TimeoutManager).FullName, FeatureState.Enabled);
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    if (TestContext.TestRunId != message.Id)
+                    {
+                        return Task.FromResult(0);
+                    }
+
+                    TestContext.WasCalled = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+
+        }
+
+
+        public class MyMessage : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+
+        const string SenderDelayedMessagesTable = "NativeDelayedMessagesForSender";
+    }
+}

--- a/src/AcceptanceTests/Sending/When_delaying_messages_natively_in_hybrid_mode.cs
+++ b/src/AcceptanceTests/Sending/When_delaying_messages_natively_in_hybrid_mode.cs
@@ -2,11 +2,9 @@
 {
     using System;
     using System.Diagnostics;
-    using System.Reflection;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using Configuration.AdvanceExtensibility;
-    using Features;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
     using NServiceBus.AcceptanceTests;
@@ -70,13 +68,11 @@
 
                     var delayedDeliverySettings = transport.DelayedDelivery();
                     delayedDeliverySettings.UseTableName(SenderDelayedMessagesTable);
-                    
-                    // run in hybrid mode, i.e. timeout manager and native delayed delivery need to be enabled
-                    // delayedDeliverySettings.DisableTimeoutManager(); is invoked by IConfigureEndpointTestExecution - need to undo it to allow hybrid mode
-                    var fieldInfo = typeof(DelayedDeliverySettings).GetField("TimeoutManagerDisabled", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                    fieldInfo.SetValue(delayedDeliverySettings, false);
-                    // re-enable timeout manager back again
-                    transport.GetSettings().Set(typeof(TimeoutManager).FullName, FeatureState.Enabled);
+
+                    // Enforce hybrid mode.
+                    // Undo delayedDeliverySettings.DisableTimeoutManager() invoked in IConfigureEndpointTestExecution.
+                    // this will force the transport to continue using TimeoutManager for incoming delayes and send delayed messages using native
+                    transport.GetSettings().Set("WellKnownConfigurationKeys.DelayedDelivery.DisableTimeoutManager", false);
                 });
             }
 

--- a/src/AcceptanceTests/Utils.cs
+++ b/src/AcceptanceTests/Utils.cs
@@ -6,7 +6,7 @@
     {
         public static string GetEnvConfiguredConnectionString()
         {
-            return Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString");
+            return Environment.GetEnvironmentVariable("AzureStorageQueueTransport_ConnectionString");
         }
 
         public static string BuildAnotherConnectionString(string connectionString)

--- a/src/NServiceBus.AzureStorageQueues.TransportTests/ConfigureAzureStorageQueueTransportInfrastructure.cs
+++ b/src/NServiceBus.AzureStorageQueues.TransportTests/ConfigureAzureStorageQueueTransportInfrastructure.cs
@@ -33,7 +33,7 @@ public class ConfigureAzureStorageQueueTransportInfrastructure : IConfigureTrans
 
         return new TransportConfigurationResult
         {
-            TransportInfrastructure = new AzureStorageQueueTransport().Initialize(settings, Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString")),
+            TransportInfrastructure = new AzureStorageQueueTransport().Initialize(settings, Environment.GetEnvironmentVariable("AzureStorageQueueTransport_ConnectionString")),
             PurgeInputQueueOnStartup = false
         };
     }

--- a/src/Tests/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.approved.cs
+++ b/src/Tests/NServiceBus.Azure.Transports.WindowsAzureStorageQueues.approved.cs
@@ -35,9 +35,10 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UnwrapMessagesWith(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, System.Func<Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage, NServiceBus.Azure.Transports.WindowsAzureStorageQueues.MessageWrapper> unwrapper) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> UseSha1ForShortening(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config) { }
     }
-    public class DelayedDeliverySettings
+    public class DelayedDeliverySettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
         public DelayedDeliverySettings() { }
+        public void DisableDelayedDelivery() { }
         public void DisableTimeoutManager() { }
         public void UseTableName(string delayedMessagesTableName) { }
     }

--- a/src/Tests/Utils.cs
+++ b/src/Tests/Utils.cs
@@ -6,7 +6,7 @@
     {
         public static string GetEnvConfiguredConnectionString()
         {
-            return Environment.GetEnvironmentVariable("AzureStorageQueueTransport.ConnectionString");
+            return Environment.GetEnvironmentVariable("AzureStorageQueueTransport_ConnectionString");
         }
     }
 }

--- a/src/Transport/Config/AzureStorageTransportExtensions.cs
+++ b/src/Transport/Config/AzureStorageTransportExtensions.cs
@@ -118,7 +118,7 @@ namespace NServiceBus
         /// </summary>
         public static DelayedDeliverySettings DelayedDelivery(this TransportExtensions<AzureStorageQueueTransport> config)
         {
-            return config.GetSettings().GetOrCreate<DelayedDeliverySettings>();
+            return new DelayedDeliverySettings(config.GetSettings());
         }
 
         internal const int MaxDegreeOfReceiveParallelism = 32;

--- a/src/Transport/Config/DelayedDeliverySettings.cs
+++ b/src/Transport/Config/DelayedDeliverySettings.cs
@@ -10,6 +10,8 @@ namespace NServiceBus
     /// <summary>Configures native delayed delivery.</summary>
     public class DelayedDeliverySettings : ExposeSettings
     {
+        public DelayedDeliverySettings() : base(new SettingsHolder()) { }
+
         internal DelayedDeliverySettings(SettingsHolder settings) : base(settings) { }
 
         /// <summary>Override the default table name used for storing delayed messages.</summary>

--- a/src/Transport/Config/DelayedDeliverySettings.cs
+++ b/src/Transport/Config/DelayedDeliverySettings.cs
@@ -2,16 +2,15 @@ namespace NServiceBus
 {
     using System;
     using System.Text.RegularExpressions;
+    using AzureStorageQueues.Config;
+    using Configuration.AdvanceExtensibility;
+    using Features;
+    using Settings;
 
     /// <summary>Configures native delayed delivery.</summary>
-    public class DelayedDeliverySettings
+    public class DelayedDeliverySettings : ExposeSettings
     {
-        internal string TableName;
-        internal bool TimeoutManagerDisabled;
-
-        internal bool TableNameWasNotOverridden => string.IsNullOrEmpty(TableName);
-
-        static Regex tableNameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9]{2,62}$", RegexOptions.Compiled);
+        internal DelayedDeliverySettings(SettingsHolder settings) : base(settings) { }
 
         /// <summary>Override the default table name used for storing delayed messages.</summary>
         /// <param name="delayedMessagesTableName">New table name.</param>
@@ -20,17 +19,37 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(delayedMessagesTableName), delayedMessagesTableName);
 
             if (tableNameRegex.IsMatch(delayedMessagesTableName) == false)
-            {
                 throw new ArgumentException($"{nameof(delayedMessagesTableName)} must match the following regular expression '{tableNameRegex}'");
-            }
 
-            TableName = delayedMessagesTableName.ToLower();
+            this.GetSettings().Set(WellKnownConfigurationKeys.DelayedDelivery.TableName, delayedMessagesTableName.ToLower());
         }
 
-        /// <summary>Disables the Timeout Manager for the endpoint. Before disabling ensure there all timeouts in the timeout store have been processed or migrated.</summary>
+        /// <summary>
+        /// Disables the Timeout Manager for the endpoint. Before disabling ensure there all timeouts in the timeout store
+        /// have been processed or migrated.
+        /// </summary>
         public void DisableTimeoutManager()
         {
-            TimeoutManagerDisabled = true;
+            this.GetSettings().Set(WellKnownConfigurationKeys.DelayedDelivery.DisableTimeoutManager, true);
         }
+
+        /// <summary>
+        /// Disable delayed delivery.
+        /// <remarks>
+        /// Disabling delayed delivery reduces costs associated with polling Azure Storage service for delayed messages that need
+        /// to be dispatched.
+        /// Do not use this setting if your endpoint required delayed messages, timeouts, or delayed retries.
+        /// </remarks>
+        /// </summary>
+        public void DisableDelayedDelivery()
+        {
+            // disable delayed delivery
+            this.GetSettings().Set(WellKnownConfigurationKeys.DelayedDelivery.DisableDelayedDelivery, true);
+
+            // disable timeout manager
+            this.GetSettings().Set(typeof(TimeoutManager).FullName, FeatureState.Disabled);
+        }
+
+        static readonly Regex tableNameRegex = new Regex(@"^[A-Za-z][A-Za-z0-9]{2,62}$", RegexOptions.Compiled);
     }
 }

--- a/src/Transport/Config/WellKnownConfigurationKeys.cs
+++ b/src/Transport/Config/WellKnownConfigurationKeys.cs
@@ -11,5 +11,12 @@
         public const string Sha1Shortener = "Transport.AzureStorageQueue.Sha1Shortener";
         public const string DegreeOfReceiveParallelism = "Transport.AzureStorageQueue.DegreeOfReceiveParallelism";
         public const string UseAccountNamesInsteadOfConnectionStrings = "Transport.AzureStorageQueue.UseAccountAliasesInsteadOfConnectionStrings";
+        
+        public static class DelayedDelivery
+        {
+            public const string TableName = "Transport.AzureStorageQueue.TableName";
+            public const string DisableTimeoutManager = "Transport.AzureStorageQueue.DisableTimeoutManager";
+            public const string DisableDelayedDelivery = "Transport.AzureStorageQueue.DisableDelayedDelivery";
+        }
     }
 }

--- a/src/Transport/DelayDelivery/NativeDelayDelivery.cs
+++ b/src/Transport/DelayDelivery/NativeDelayDelivery.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using AzureStorageQueues.Config;
     using DelayedDelivery;
     using DeliveryConstraints;
     using Features;
@@ -59,7 +60,7 @@
         {
             var externalTimeoutManagerAddress = settings.GetOrDefault<string>("NServiceBus.ExternalTimeoutManagerAddress") != null;
             var timeoutManagerFeatureActive = settings.GetOrDefault<FeatureState>(typeof(TimeoutManager).FullName) == FeatureState.Active;
-            var timeoutManagerDisabled = settings.Get<DelayedDeliverySettings>().TimeoutManagerDisabled;
+            var timeoutManagerDisabled = settings.GetOrDefault<bool>(WellKnownConfigurationKeys.DelayedDelivery.DisableTimeoutManager);
 
             if (externalTimeoutManagerAddress)
             {


### PR DESCRIPTION
Fixes #292 (alternative approach)

This PR takes into consideration the [hybrid mode](https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/294#issuecomment-348385339), where TimeoutManager and native Delayed Delivery run side by side.

To implement this and be complient with v8, change to `DelayedDeliverySettings` had to be [SemVer non-complient](https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/296/commits/1542425b399b64c10ec18138133a30ad990d2947) (inherites from `ExposeSettings` just like in v8). That's the reason why this is not a patch only, but also a minor - adding new API `.DisableDelayedDelivery()`.