### PR TITLE
Remove MessageWrapper from Conventions and MessageMetadataRegistry

### DIFF
--- a/src/Transport/AzureStorageQueueTransport.cs
+++ b/src/Transport/AzureStorageQueueTransport.cs
@@ -2,14 +2,12 @@ namespace NServiceBus
 {
     using System;
     using System.Reflection;
-    using Azure.Transports.WindowsAzureStorageQueues;
     using AzureStorageQueues;
     using MessageInterfaces;
     using Routing;
     using Serialization;
     using Settings;
     using Transport;
-    using Unicast.Messages;
 
     /// <summary>
     /// Transport definition for AzureStorageQueue
@@ -27,12 +25,6 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(connectionString), connectionString);
             // configure JSON instead of XML as the default serializer:
             SetMainSerializer(settings, new JsonSerializer());
-
-            // register the MessageWrapper as a system message to have it registered in mappings and serializers
-            settings.GetOrCreate<Conventions>().AddSystemMessagesConventions(t => t == typeof(MessageWrapper));
-
-            // register metadata of the wrapper for the sake of XML serializer
-            settings.Get<MessageMetadataRegistry>().GetMessageMetadata(typeof(MessageWrapper));
 
             DefaultConfigurationValues.Apply(settings);
 


### PR DESCRIPTION
Related to https://github.com/Particular/ServiceControl.TransportAdapter/issues/23

- Registering the MessageWrapper in the conventions as a system message is not necessary because MessageWrapper implements IMessage
- Registering the MessageWrapper in the message metadata registry is not necessary because the XmlSerializer caches types during runtime when necessary

@Scooletz  and I did some digging and it looks like those changes were introduced for the acceptance tests around the 7.0.0 RC timeframe. When the core v6.0.0 final was released the XmlSerializer was already implemented with runtime caching of types where necessary. 

Related issue https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/124
The related PR for the issue above https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/125
as well as https://github.com/Particular/NServiceBus.AzureStorageQueues/commit/e5968b8ebdafcfb8f610fa973d027ec6a2513757

We smoked tested these changes also against core v6.0.0 with messages already in the queue sent by an unpatched version of the ASQ transport. We did it for the 6.0.0 to cover the whole nuspec range. Everything works smoothly and the xml envelop when used with the XmlSerializer is still the same and thus backward compliant.

In addition to that we sent in a PR that showes that all acceptance tests still pass even with the XmlSerializer as a wrapper serializer

https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/305

### Before

`<?xml version="1.0"?><MessageWrapper xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://tempuri.net/NServiceBus.Azure.Transports.WindowsAzureStorageQueues">...`

### After

`<?xml version="1.0"?><MessageWrapper xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://tempuri.net/NServiceBus.Azure.Transports.WindowsAzureStorageQueues">`

  