### PR TITLE
Hotfix 7.5.2

### DIFF
--- a/src/Transport/AzureStorageQueueTransport.cs
+++ b/src/Transport/AzureStorageQueueTransport.cs
@@ -2,14 +2,12 @@ namespace NServiceBus
 {
     using System;
     using System.Reflection;
-    using Azure.Transports.WindowsAzureStorageQueues;
     using AzureStorageQueues;
     using MessageInterfaces;
     using Routing;
     using Serialization;
     using Settings;
     using Transport;
-    using Unicast.Messages;
 
     /// <summary>
     /// Transport definition for AzureStorageQueue
@@ -27,12 +25,6 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(connectionString), connectionString);
             // configure JSON instead of XML as the default serializer:
             SetMainSerializer(settings, new JsonSerializer());
-
-            // register the MessageWrapper as a system message to have it registered in mappings and serializers
-            settings.GetOrCreate<Conventions>().AddSystemMessagesConventions(t => t == typeof(MessageWrapper));
-
-            // register metadata of the wrapper for the sake of XML serializer
-            settings.Get<MessageMetadataRegistry>().GetMessageMetadata(typeof(MessageWrapper));
 
             DefaultConfigurationValues.Apply(settings);
 


### PR DESCRIPTION
Remove unnecessary settings to simplify transport adapter scenarios.

- Registering the MessageWrapper in the conventions as a system message is not necessary because MessageWrapper implements IMessage
- Registering the MessageWrapper in the message metadata registry is not necessary because the XmlSerializer caches types during runtime when necessary

For more information see https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/304