### PR TITLE
[Spike] Catch stop exception

### DIFF
--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -193,7 +193,7 @@
         {
             if (PollerCanBeUsed())
             {
-                var isAtMostOnce = GetRequiredTransactionMode(settings) == TransportTransactionMode.None;
+                var isAtMostOnce = GetRequiredTransactionMode() == TransportTransactionMode.None;
                 var maximumWaitTime = settings.Get<TimeSpan>(WellKnownConfigurationKeys.ReceiverMaximumWaitTimeWhenIdle);
                 var peekInterval = settings.Get<TimeSpan>(WellKnownConfigurationKeys.ReceiverPeekInterval);
                 poller = new DelayedMessagesPoller(delayedDelivery.Table, connectionString, settings.ErrorQueueAddress(), isAtMostOnce, BuildDispatcher(), new BackoffStrategy(maximumWaitTime, peekInterval));
@@ -204,7 +204,6 @@
             return TaskEx.CompletedTask;
         }
 
-        public override Task Stop()
         public override async Task Stop()
         {
             nativeDelayedMessagesCancellationSource?.Cancel();
@@ -221,9 +220,9 @@
             }
         }
 
-        static TransportTransactionMode GetRequiredTransactionMode(ReadOnlySettings settings)
+        TransportTransactionMode GetRequiredTransactionMode()
         {
-            var transportTransactionSupport = settings.Get<TransportInfrastructure>().TransactionMode;
+            var transportTransactionSupport = TransactionMode;
 
             //if user haven't asked for a explicit level use what the transport supports
             if (!settings.TryGet(out TransportTransactionMode requestedTransportTransactionMode))

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -205,9 +205,20 @@
         }
 
         public override Task Stop()
+        public override async Task Stop()
         {
             nativeDelayedMessagesCancellationSource?.Cancel();
-            return poller != null ? poller.Stop() : TaskEx.CompletedTask;
+
+            try
+            {
+                if (poller != null)
+                {
+                    await poller.Stop().ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
         }
 
         static TransportTransactionMode GetRequiredTransactionMode(ReadOnlySettings settings)


### PR DESCRIPTION
I noticed two things while testing a change to core to call start/stop on the transport infrastructure when running the transport tests and wanted to get some thoughts from the @Particular/azure-maintainers regarding those. This PR's purpose is mostly get a better understanding of the current code and should be closed once discussed.

* stop can throw a `TaskCanceledException` which won't be handled anywhere. It seems this exception is quite expected as it skips a call to `Task.Delay`. Core will catch this exception and log an error which seems weird as this doesn't really seem to be an actual exception? (Also, the transport tests will have to catch that exception too once we start calling Start/Stop on the transport infrastructure).

* `GetRequiredTransactionMode` in the `Start` method uses the settings to get access to the `TransportInfrastructure` class (`settings.Get<TransportInfrastructure>().TransactionMode`). This seems rather weird as this code is called from within the class implementing the `TransportInfrastructure`. Once the transport tests start calling Start on the transport infrastructure, this would fail as the test doesn't set this setting. You can argue that this doesn't correspond with core's behavior, I don't understand why this code is written that way though as it seems it could be easily avoided in the first place.

ping @Particular/azure-maintainers 