### PR TITLE
Update Storage client and extend default TTL

### DIFF
--- a/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
 
   <!-- Force latest versions -->
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.*" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.1.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0" />
     <!-- TODO: replace with "3.*" when NUnit bug is fixed -->

--- a/src/AcceptanceTests/Sending/When_message_is_sent_with_time_to_be_received_set_to_more_than_30_days.cs
+++ b/src/AcceptanceTests/Sending/When_message_is_sent_with_time_to_be_received_set_to_more_than_30_days.cs
@@ -6,7 +6,7 @@
     using EndpointTemplates;
     using NUnit.Framework;
 
-    public class When_message_is_sent_with_time_to_be_received_set_to_more_than_7_days : NServiceBusAcceptanceTest
+    public class When_message_is_sent_with_time_to_be_received_set_to_more_than_30_days : NServiceBusAcceptanceTest
     {
         [Test]
         public Task Should_throw_exception()
@@ -15,7 +15,7 @@
                 .WithEndpoint<ReceiverEndPoint>(b => b.When((bus, c) =>
                 {
                     var exception = Assert.ThrowsAsync<InvalidOperationException>(() => bus.SendLocal(new MessageNotToBeSent()));
-                    var expectedMessage = $"TimeToBeReceived is set to more than 7 days (maximum for Azure Storage queue) for message type '{typeof(MessageNotToBeSent).FullName}'.";
+                    var expectedMessage = $"TimeToBeReceived is set to more than 30 days for message type '{typeof(MessageNotToBeSent).FullName}'.";
                     Assert.AreEqual(expectedMessage, exception.Message);
                     c.ExceptionReceived = true;
 
@@ -40,7 +40,7 @@
             public Context Context { get; set; }
         }
 
-        [TimeToBeReceived("7.00:00:01")]
+        [TimeToBeReceived("31.00:00:01")]
         public class MessageNotToBeSent : IMessage
         {
         }

--- a/src/Tests/NServiceBus.AzureStorageQueues.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureStorageQueues.Tests.csproj
@@ -15,7 +15,7 @@
   <!-- Force latest versions -->
   <ItemGroup>
     <PackageReference Include="Particular.Approvals" Version="0.1.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.*" />
     <PackageReference Include="NServiceBus" Version="7.1.0" />
     <!-- requries a version that works with PublicApiGenerator (Mono.Cecil) -->
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />

--- a/src/Transport/DelayDelivery/LockManager.cs
+++ b/src/Transport/DelayDelivery/LockManager.cs
@@ -45,7 +45,7 @@
                 return true;
             }
             catch (StorageException exception)
-                when (exception.RequestInformation.ExtendedErrorInformation.ErrorCode == BlobErrorCodeStrings.LeaseIdMismatchWithLeaseOperation)
+                when (exception.RequestInformation.ErrorCode == BlobErrorCodeStrings.LeaseIdMismatchWithLeaseOperation)
             {
                 lease = null;
                 return false;

--- a/src/Transport/Dispatcher.cs
+++ b/src/Transport/Dispatcher.cs
@@ -79,10 +79,10 @@
             }
 
             // user explicitly specified TimeToBeReceived that is not TimeSpan.MaxValue - fail
-            if (timeToBeReceived != null && timeToBeReceived.Value > CloudQueueMessage.MaxTimeToLive && timeToBeReceived != TimeSpan.MaxValue)
+            if (timeToBeReceived != null && timeToBeReceived.Value > CloudQueueMessageMaxTimeToLive && timeToBeReceived != TimeSpan.MaxValue)
             {
                 var messageType = operation.Message.Headers[Headers.EnclosedMessageTypes].Split(',').First();
-                throw new InvalidOperationException($"TimeToBeReceived is set to more than 7 days (maximum for Azure Storage queue) for message type '{messageType}'.");
+                throw new InvalidOperationException($"TimeToBeReceived is set to more than 30 days for message type '{messageType}'.");
             }
 
             if (timeToBeReceived.HasValue)
@@ -93,14 +93,15 @@
                 {
                     throw new Exception($"Message cannot be sent with a provided delay of {timeToBeReceived.Value.TotalMilliseconds} ms.");
                 }
+
                 timeToBeReceived = TimeSpan.FromSeconds(seconds);
             }
 
             var wrapper = BuildMessageWrapper(operation, queue);
-            await Send(wrapper, sendQueue, timeToBeReceived).ConfigureAwait(false);
+            await Send(wrapper, sendQueue, timeToBeReceived ?? CloudQueueMessageMaxTimeToLive).ConfigureAwait(false);
         }
 
-        Task Send(MessageWrapper wrapper, CloudQueue sendQueue, TimeSpan? timeToBeReceived)
+        Task Send(MessageWrapper wrapper, CloudQueue sendQueue, TimeSpan timeToBeReceived)
         {
             CloudQueueMessage rawMessage;
             using (var stream = new MemoryStream())
@@ -146,13 +147,15 @@
             };
         }
 
-        QueueAddressGenerator addressGenerator;
-        AzureStorageAddressingSettings addressing;
         readonly CreateQueueClients createQueueClients;
-
-        static ILog logger = LogManager.GetLogger<Dispatcher>();
-        ConcurrentDictionary<string, Task<bool>> rememberExistence = new ConcurrentDictionary<string, Task<bool>>();
         readonly MessageWrapperSerializer serializer;
         readonly Func<UnicastTransportOperation, CancellationToken, Task<bool>> shouldSend;
+
+        readonly QueueAddressGenerator addressGenerator;
+        readonly AzureStorageAddressingSettings addressing;
+        readonly ConcurrentDictionary<string, Task<bool>> rememberExistence = new ConcurrentDictionary<string, Task<bool>>();
+
+        static readonly TimeSpan CloudQueueMessageMaxTimeToLive = TimeSpan.FromDays(30);
+        static readonly ILog logger = LogManager.GetLogger<Dispatcher>();
     }
 }

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <!-- Minimum requried version for WindowsAzure.Storage is 8.2.0 -->
-    <PackageReference Include="WindowsAzure.Storage" Version="[8.2.0, 9.0.0)" />
+    <PackageReference Include="WindowsAzure.Storage" Version="[9.3.2, 10.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
     <PackageReference Include="Fody" Version="2.2.1" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.5.2" PrivateAssets="All" />

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Fody" Version="2.2.1" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.5.2" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
-    <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.2.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <!-- Minimum requried version for WindowsAzure.Storage is 8.2.0 -->
-    <PackageReference Include="WindowsAzure.Storage" Version="[9.3.2, 10.0.0)" />
+    <PackageReference Include="WindowsAzure.Storage" Version="[9.0.0, 10.0.0)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
     <PackageReference Include="Fody" Version="2.2.1" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.5.2" PrivateAssets="All" />

--- a/src/TransportTests/NServiceBus.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureStorageQueues.TransportTests.csproj
@@ -13,7 +13,7 @@
 
   <!-- Force latest versions -->
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />


### PR DESCRIPTION
Fixes #325 
Supersedes #334 

* New Storage client 9.3.2
* Default message TTL set to 30 days (not using infinite)