### PR TITLE
Support 80 update dev tooling

### DIFF
--- a/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.AzureStorageQueues.AcceptanceTests.csproj
@@ -14,10 +14,9 @@
     <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0" />
-    <!-- TODO: replace with "3.*" when NUnit bug is fixed -->
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/NServiceBus.AzureStorageQueues.Tests.csproj
+++ b/src/Tests/NServiceBus.AzureStorageQueues.Tests.csproj
@@ -17,10 +17,9 @@
     <PackageReference Include="Particular.Approvals" Version="0.1.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0" />
-    <!-- TODO: replace with "3.*" when NUnit bug is fixed -->
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="PublicApiGenerator" Version="7.0.1" />
   </ItemGroup>
 

--- a/src/Transport/NServiceBus.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.AzureStorageQueues.csproj
@@ -20,12 +20,7 @@
     <PackageReference Include="Janitor.Fody" Version="1.5.2" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="All" />
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.5.0" />
+    <PackageReference Include="Particular.Packaging" Version="0.2.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/TransportTests/NServiceBus.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureStorageQueues.TransportTests.csproj
@@ -14,10 +14,9 @@
   <!-- Force latest versions -->
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
-    <!-- TODO: replace with "3.*" when NUnit bug is fixed -->
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This updates development tooling on the `support-8.0` branch.
Note: This should not be squashed.