### PR TITLE
[WIP] Recoverability seam alignment

### DIFF
--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -11,10 +11,11 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
     class AtLeastOnceReceiveStrategy : ReceiveStrategy
     {
-        public AtLeastOnceReceiveStrategy(Func<MessageContext, Task> pipeline, Func<ErrorContext, Task<ErrorHandleResult>> errorPipe)
+        public AtLeastOnceReceiveStrategy(Func<MessageContext, Task> pipeline, Func<ErrorContext, Task<ErrorHandleResult>> errorPipe, CriticalError criticalError)
         {
             this.pipeline = pipeline;
             this.errorPipe = errorPipe;
+            this.criticalError = criticalError;
         }
 
         public override async Task Receive(MessageRetrieved retrieved, MessageWrapper message)
@@ -56,8 +57,10 @@ namespace NServiceBus.Transport.AzureStorageQueues
                 }
                 catch (Exception e)
                 {
-                    Logger.Warn("The error pipeline wasn't able to handle the exception.", e);
+                    criticalError.Raise($"Failed to execute recoverability policy for message with native ID: `{message.Id}`", e);
+
                     await retrieved.Nack().ConfigureAwait(false);
+
                     return;
                 }
 
@@ -78,6 +81,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
         readonly Func<MessageContext, Task> pipeline;
         readonly Func<ErrorContext, Task<ErrorHandleResult>> errorPipe;
+        readonly CriticalError criticalError;
 
         static readonly ILog Logger = LogManager.GetLogger<ReceiveStrategy>();
     }

--- a/src/Transport/MessagePump.cs
+++ b/src/Transport/MessagePump.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
             circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("AzureStorageQueue-MessagePump", TimeToWaitBeforeTriggering, ex => criticalError.Raise("Failed to receive message from Azure Storage Queue.", ex));
             messageReceiver.PurgeOnStartup = settings.PurgeOnStartup;
 
-            receiveStrategy = ReceiveStrategy.BuildReceiveStrategy(onMessage, onError, settings.RequiredTransactionMode);
+            receiveStrategy = ReceiveStrategy.BuildReceiveStrategy(onMessage, onError, settings.RequiredTransactionMode, criticalError);
 
             return messageReceiver.Init(settings.InputQueue, settings.ErrorQueue);
         }

--- a/src/Transport/ReceiveStrategy.cs
+++ b/src/Transport/ReceiveStrategy.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
     {
         public abstract Task Receive(MessageRetrieved retrieved, MessageWrapper message);
 
-        public static ReceiveStrategy BuildReceiveStrategy(Func<MessageContext, Task> pipe, Func<ErrorContext, Task<ErrorHandleResult>> errorPipe, TransportTransactionMode transactionMode)
+        public static ReceiveStrategy BuildReceiveStrategy(Func<MessageContext, Task> pipe, Func<ErrorContext, Task<ErrorHandleResult>> errorPipe, TransportTransactionMode transactionMode, CriticalError criticalError)
         {
             // ReSharper disable once SwitchStatementMissingSomeCases
             switch (transactionMode)
@@ -17,7 +17,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
                 case TransportTransactionMode.None:
                     return new AtMostOnceReceiveStrategy(pipe, errorPipe);
                 case TransportTransactionMode.ReceiveOnly:
-                    return new AtLeastOnceReceiveStrategy(pipe, errorPipe);
+                    return new AtLeastOnceReceiveStrategy(pipe, errorPipe, criticalError);
                 default:
                     throw new NotSupportedException($"The TransportTransactionMode {transactionMode} is not supported");
             }

--- a/src/TransportTests/ConfigureAzureStorageQueueTransportInfrastructure.cs
+++ b/src/TransportTests/ConfigureAzureStorageQueueTransportInfrastructure.cs
@@ -9,7 +9,6 @@ using NServiceBus.Serialization;
 using NServiceBus.Settings;
 using NServiceBus.TransportTests;
 using NServiceBus.Unicast.Messages;
-using NUnit.Framework;
 
 public class ConfigureAzureStorageQueueTransportInfrastructure : IConfigureTransportInfrastructure
 {
@@ -25,12 +24,6 @@ public class ConfigureAzureStorageQueueTransportInfrastructure : IConfigureTrans
             registry = (MessageMetadataRegistry)Activator.CreateInstance(typeof(MessageMetadataRegistry), flags, null, new object[] { new Func<Type, bool>(t => conventions.IsMessageType(t)) }, CultureInfo.InvariantCulture);
 
             settings.Set(registry);
-        }
-
-        var methodName = TestContext.CurrentContext.Test.MethodName;
-        if (methodName == nameof(When_on_error_throws.Should_reinvoke_on_error_with_original_exception))
-        {
-            throw new IgnoreException("ASQ uses a circuit breaker that is triggered after specific period of time. Critical errors are not reported immediately");
         }
 
         settings.Set(AzureStorageQueueTransport.SerializerSettingsKey, Tuple.Create<SerializationDefinition, SettingsHolder>(new XmlSerializer(), settings));

--- a/src/TransportTests/NServiceBus.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureStorageQueues.TransportTests.csproj
@@ -17,17 +17,14 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.1.6" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.1.6"/>
   </ItemGroup>
 
   <!-- Replaces transport tests/infrastructure from Core 7.1.6. See KTLO issue https://github.com/Particular/KeepTheLightsOn/issues/218  -->
   <ItemGroup>
-    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\When_on_error_throws.cs" />
-    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\NServiceBusTransportTest.cs" />
-    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\TransportTestLoggerFactory.cs" />
-    <Compile Include="NServiceBusTransportTest.cs" />
-    <Compile Include="TransportTestLoggerFactory.cs" />
-    <Compile Include="When_on_error_throws.cs" />
+    <Compile Remove="\**\NServiceBus.TransportTests.Sources\**\When_on_error_throws.cs" />
+    <Compile Remove="\**\NServiceBus.TransportTests.Sources\**\NServiceBusTransportTest.cs" />
+    <Compile Remove="\**\NServiceBus.TransportTests.Sources\**\TransportTestLoggerFactory.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TransportTests/NServiceBus.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.AzureStorageQueues.TransportTests.csproj
@@ -17,7 +17,17 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.1.6" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.1.6" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <!-- Replaces transport tests/infrastructure from Core 7.1.6. See KTLO issue https://github.com/Particular/KeepTheLightsOn/issues/218  -->
+  <ItemGroup>
+    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\When_on_error_throws.cs" />
+    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\NServiceBusTransportTest.cs" />
+    <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\TransportTestLoggerFactory.cs" />
+    <Compile Include="NServiceBusTransportTest.cs" />
+    <Compile Include="TransportTestLoggerFactory.cs" />
+    <Compile Include="When_on_error_throws.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TransportTests/NServiceBusTransportTest.cs
+++ b/src/TransportTests/NServiceBusTransportTest.cs
@@ -1,0 +1,288 @@
+namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeliveryConstraints;
+    using Extensibility;
+    using Logging;
+    using NUnit.Framework;
+    using Routing;
+    using Settings;
+    using Transport;
+
+    public abstract class NServiceBusTransportTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            testId = Guid.NewGuid().ToString();
+
+            LogFactory = new TransportTestLoggerFactory();
+            LogManager.UseFactory(LogFactory);
+
+            //when using [TestCase] NUnit will reuse the same test instance so we need to make sure that the message pump is a fresh one
+            MessagePump = null;
+            TransportInfrastructure = null;
+            Configurer = null;
+            testCancellationTokenSource = null;
+        }
+
+        static IConfigureTransportInfrastructure CreateConfigurer()
+        {
+            var transportToUse = EnvironmentHelper.GetEnvironmentVariable("Transport_UseSpecific");
+
+            if (string.IsNullOrWhiteSpace(transportToUse))
+            {
+                var coreAssembly = typeof(IMessage).Assembly;
+
+                var nonCoreTransport = transportDefinitions.Value.FirstOrDefault(t => t.Assembly != coreAssembly);
+
+                transportToUse = nonCoreTransport?.Name ?? DefaultTransportDescriptorKey;
+            }
+
+            var typeName = $"Configure{transportToUse}Infrastructure";
+
+            var configurerType = Type.GetType(typeName, false);
+
+            if (configurerType == null)
+            {
+                throw new InvalidOperationException($"Transport Test project must include a non-namespaced class named '{typeName}' implementing {typeof(IConfigureTransportInfrastructure).Name}.");
+            }
+
+            if (!(Activator.CreateInstance(configurerType) is IConfigureTransportInfrastructure configurer))
+            {
+                throw new InvalidOperationException($"{typeName} does not implement {typeof(IConfigureTransportInfrastructure).Name}.");
+            }
+
+            return configurer;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            testCancellationTokenSource?.Dispose();
+            MessagePump?.Stop().GetAwaiter().GetResult();
+            TransportInfrastructure?.Stop().GetAwaiter().GetResult();
+            Configurer?.Cleanup().GetAwaiter().GetResult();
+
+            transportSettings.Clear();
+        }
+
+        protected async Task StartPump(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, TransportTransactionMode transactionMode, Action<string, Exception> onCriticalError = null)
+        {
+            InputQueueName = GetTestName() + transactionMode;
+            ErrorQueueName = $"{InputQueueName}.error";
+
+            transportSettings.Set("NServiceBus.Routing.EndpointName", InputQueueName);
+            transportSettings.Set(new StartupDiagnosticEntries());
+
+            var queueBindings = new QueueBindings();
+            queueBindings.BindReceiving(InputQueueName);
+            queueBindings.BindSending(ErrorQueueName);
+            transportSettings.Set(ErrorQueueSettings.SettingsKey, ErrorQueueName);
+            transportSettings.Set(queueBindings);
+
+            transportSettings.Set(new EndpointInstances());
+
+            Configurer = CreateConfigurer();
+
+            var configuration = Configurer.Configure(transportSettings, transactionMode);
+
+            TransportInfrastructure = configuration.TransportInfrastructure;
+
+            IgnoreUnsupportedTransactionModes(transactionMode);
+            IgnoreUnsupportedDeliveryConstraints();
+
+            ReceiveInfrastructure = TransportInfrastructure.ConfigureReceiveInfrastructure();
+
+            var queueCreator = ReceiveInfrastructure.QueueCreatorFactory();
+            var userName = GetUserName();
+            await queueCreator.CreateQueueIfNecessary(queueBindings, userName);
+
+            await TransportInfrastructure.Start();
+
+            SendInfrastructure = TransportInfrastructure.ConfigureSendInfrastructure();
+            lazyDispatcher = new Lazy<IDispatchMessages>(() => SendInfrastructure.DispatcherFactory());
+
+            MessagePump = ReceiveInfrastructure.MessagePumpFactory();
+            await MessagePump.Init(
+                context =>
+                {
+                    if (context.Headers.ContainsKey(TestIdHeaderName) && context.Headers[TestIdHeaderName] == testId)
+                    {
+                        return onMessage(context);
+                    }
+
+                    return Task.FromResult(0);
+                },
+                context =>
+                {
+                    if (context.Message.Headers.ContainsKey(TestIdHeaderName) && context.Message.Headers[TestIdHeaderName] == testId)
+                    {
+                        return onError(context);
+                    }
+
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                },
+                new FakeCriticalError(onCriticalError),
+                new PushSettings(InputQueueName, ErrorQueueName, configuration.PurgeInputQueueOnStartup, transactionMode));
+
+            MessagePump.Start(configuration.PushRuntimeSettings);
+        }
+
+        string GetUserName()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                return $"{Environment.UserDomainName}\\{Environment.UserName}";
+            }
+
+            return Environment.UserName;
+        }
+
+        void IgnoreUnsupportedDeliveryConstraints()
+        {
+            var supportedDeliveryConstraints = TransportInfrastructure.DeliveryConstraints.ToList();
+            var unsupportedDeliveryConstraints = requiredDeliveryConstraints.Where(required => !supportedDeliveryConstraints.Contains(required))
+                .ToList();
+
+            if (unsupportedDeliveryConstraints.Any())
+            {
+                var unsupported = string.Join(",", unsupportedDeliveryConstraints.Select(c => c.Name));
+                Assert.Ignore($"Transport doesn't support required delivery constraint(s) {unsupported}");
+            }
+        }
+
+        void IgnoreUnsupportedTransactionModes(TransportTransactionMode requestedTransactionMode)
+        {
+            if (TransportInfrastructure.TransactionMode < requestedTransactionMode)
+            {
+                Assert.Ignore($"Only relevant for transports supporting {requestedTransactionMode} or higher");
+            }
+        }
+
+        protected Task SendMessage(string address,
+            Dictionary<string, string> headers = null,
+            TransportTransaction transportTransaction = null,
+            List<DeliveryConstraint> deliveryConstraints = null,
+            DispatchConsistency dispatchConsistency = DispatchConsistency.Default)
+        {
+            var messageId = Guid.NewGuid().ToString();
+            var message = new OutgoingMessage(messageId, headers ?? new Dictionary<string, string>(), new byte[0]);
+
+            if (message.Headers.ContainsKey(TestIdHeaderName) == false)
+            {
+                message.Headers.Add(TestIdHeaderName, testId);
+            }
+
+            var dispatcher = lazyDispatcher.Value;
+
+            if (transportTransaction == null)
+            {
+                transportTransaction = new TransportTransaction();
+            }
+
+            var transportOperation = new TransportOperation(message, new UnicastAddressTag(address), dispatchConsistency, deliveryConstraints ?? new List<DeliveryConstraint>());
+
+            return dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, new ContextBag());
+        }
+
+        protected void OnTestTimeout(Action onTimeoutAction)
+        {
+            testCancellationTokenSource = Debugger.IsAttached ? new CancellationTokenSource() : new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            testCancellationTokenSource.Token.Register(onTimeoutAction);
+        }
+
+        protected void RequireDeliveryConstraint<T>() where T : DeliveryConstraint
+        {
+            requiredDeliveryConstraints.Add(typeof(T));
+        }
+
+        static string GetTestName()
+        {
+            var index = 1;
+            var frame = new StackFrame(index);
+            Type type;
+
+            while (true)
+            {
+                type = frame.GetMethod().DeclaringType;
+
+                if (type != null && !type.IsAbstract && typeof(NServiceBusTransportTest).IsAssignableFrom(type))
+                {
+                    break;
+                }
+
+                frame = new StackFrame(++index);
+            }
+
+            var classCallingUs = type.FullName.Split('.').Last();
+
+            var testName = classCallingUs.Split('+').First();
+
+            testName = testName.Replace("When_", "");
+
+            testName = Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(testName);
+
+            testName = testName.Replace("_", "");
+
+            return testName;
+        }
+
+        protected string InputQueueName;
+        protected string ErrorQueueName;
+        protected TransportTestLoggerFactory LogFactory;
+
+        string testId;
+
+        List<Type> requiredDeliveryConstraints = new List<Type>();
+        SettingsHolder transportSettings = new SettingsHolder();
+        Lazy<IDispatchMessages> lazyDispatcher;
+        TransportReceiveInfrastructure ReceiveInfrastructure;
+        TransportSendInfrastructure SendInfrastructure;
+        TransportInfrastructure TransportInfrastructure;
+        IPushMessages MessagePump;
+        CancellationTokenSource testCancellationTokenSource;
+        IConfigureTransportInfrastructure Configurer;
+
+        const string DefaultTransportDescriptorKey = "LearningTransport";
+        const string TestIdHeaderName = "TransportTest.TestId";
+
+        static Lazy<List<Type>> transportDefinitions = new Lazy<List<Type>>(() => TypeScanner.GetAllTypesAssignableTo<TransportDefinition>().ToList());
+
+        class FakeCriticalError : CriticalError
+        {
+            public FakeCriticalError(Action<string, Exception> errorAction) : base(null)
+            {
+                this.errorAction = errorAction ?? ((s, e) => { });
+            }
+
+            public override void Raise(string errorMessage, Exception exception)
+            {
+                errorAction(errorMessage, exception);
+            }
+
+            Action<string, Exception> errorAction;
+        }
+
+        class EnvironmentHelper
+        {
+            public static string GetEnvironmentVariable(string variable)
+            {
+                var candidate = Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.User);
+
+                if (string.IsNullOrWhiteSpace(candidate))
+                {
+                    return Environment.GetEnvironmentVariable(variable);
+                }
+
+                return candidate;
+            }
+        }
+    }
+}

--- a/src/TransportTests/TransportTestLoggerFactory.cs
+++ b/src/TransportTests/TransportTestLoggerFactory.cs
@@ -1,0 +1,133 @@
+namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using Logging;
+    using NUnit.Framework;
+
+    public class TransportTestLoggerFactory : ILoggerFactory
+    {
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new TransportTestLogger(name, LogItems);
+        }
+
+        public List<LogItem> LogItems { get; } = new List<LogItem>();
+
+        public class LogItem
+        {
+            public LogLevel Level;
+            // ReSharper disable once NotAccessedField.Global
+            public string Message;
+        }
+
+        class TransportTestLogger : ILog
+        {
+            public TransportTestLogger(string name, List<LogItem> logItems)
+            {
+                this.name = name;
+                this.logItems = logItems;
+            }
+
+            public bool IsDebugEnabled { get; } = true;
+            public bool IsInfoEnabled { get; } = true;
+            public bool IsWarnEnabled { get; } = true;
+            public bool IsErrorEnabled { get; } = true;
+            public bool IsFatalEnabled { get; } = true;
+
+            public void Debug(string message)
+            {
+                Log(LogLevel.Debug, message);
+            }
+
+            public void Debug(string message, Exception exception)
+            {
+                Log(LogLevel.Debug, $"{message} {exception}");
+            }
+
+            public void DebugFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Debug, string.Format(format, args));
+            }
+
+            public void Info(string message)
+            {
+                Log(LogLevel.Info, message);
+            }
+
+            public void Info(string message, Exception exception)
+            {
+                Log(LogLevel.Info, $"{message} {exception}");
+            }
+
+            public void InfoFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Info, string.Format(format, args));
+            }
+
+            public void Warn(string message)
+            {
+                Log(LogLevel.Warn, message);
+            }
+
+            public void Warn(string message, Exception exception)
+            {
+                Log(LogLevel.Warn, $"{message} {exception}");
+            }
+
+            public void WarnFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Warn, string.Format(format, args));
+            }
+
+            public void Error(string message)
+            {
+                Log(LogLevel.Error, message);
+            }
+
+            public void Error(string message, Exception exception)
+            {
+                Log(LogLevel.Error, $"{message} {exception}");
+            }
+
+            public void ErrorFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Error, string.Format(format, args));
+            }
+
+            public void Fatal(string message)
+            {
+                Log(LogLevel.Fatal, message);
+            }
+
+            public void Fatal(string message, Exception exception)
+            {
+                Log(LogLevel.Fatal, $"{message} {exception}");
+            }
+
+            public void FatalFormat(string format, params object[] args)
+            {
+                Log(LogLevel.Fatal, string.Format(format, args));
+            }
+
+            void Log(LogLevel level, string message)
+            {
+                logItems.Add(new LogItem
+                {
+                    Level = level,
+                    Message = message
+                });
+
+                TestContext.WriteLine($"{DateTime.Now:T} {level} {name}: {message}");
+            }
+
+            string name;
+            List<LogItem> logItems;
+        }
+    }
+}

--- a/src/TransportTests/When_on_error_throws.cs
+++ b/src/TransportTests/When_on_error_throws.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.TransportTests
 
             Assert.AreEqual("Simulated exception", errorContext.Exception.Message, "Should retry the message");
             Assert.True(criticalErrorCalled, "Should invoke critical error");
-            StringAssert.Contains(nativeMessageId, criticalErrorMessage, "Should include the native message id in the critical error message");
+            Assert.AreEqual($"Failed to execute recoverability policy for message with native ID: `{nativeMessageId}`", criticalErrorMessage);
             Assert.False(LogFactory.LogItems.Any(item => item.Level > LogLevel.Info));
         }
     }

--- a/src/TransportTests/When_on_error_throws.cs
+++ b/src/TransportTests/When_on_error_throws.cs
@@ -1,0 +1,65 @@
+namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Logging;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_on_error_throws : NServiceBusTransportTest
+    {
+        // [TestCase(TransportTransactionMode.None)] -- not relevant
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_invoke_critical_error_and_retry(TransportTransactionMode transactionMode)
+        {
+            var onErrorCalled = new TaskCompletionSource<ErrorContext>();
+            var criticalErrorCalled = false;
+            string criticalErrorMessage = null;
+
+            OnTestTimeout(() => onErrorCalled.SetCanceled());
+
+            var firstInvocation = true;
+            string nativeMessageId = null;
+
+            await StartPump(
+                context =>
+                {
+                    nativeMessageId = context.MessageId;
+
+                    throw new Exception("Simulated exception");
+                },
+                context =>
+                {
+                    if (firstInvocation)
+                    {
+                        firstInvocation = false;
+
+                        throw new Exception("Exception from onError");
+                    }
+
+                    onErrorCalled.SetResult(context);
+
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                },
+                transactionMode,
+                (message, exception) =>
+                {
+                    criticalErrorCalled = true;
+                    criticalErrorMessage = message;
+                }
+                );
+
+            await SendMessage(InputQueueName);
+
+            var errorContext = await onErrorCalled.Task;
+
+            Assert.AreEqual("Simulated exception", errorContext.Exception.Message, "Should retry the message");
+            Assert.True(criticalErrorCalled, "Should invoke critical error");
+            StringAssert.Contains(nativeMessageId, criticalErrorMessage, "Should include the native message id in the critical error message");
+            Assert.False(LogFactory.LogItems.Any(item => item.Level > LogLevel.Info));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #358

The change is ensuring the following takes place when recoverability fails:

- Critical error is raised
- Critical error message include failing message ID
- Exception passed with critical error is no longer logged (failed recoverability logs it already)