### PR TITLE
Remove merge=union git attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -64,11 +64,6 @@
 *.bat text eol=crlf
 
 # Custom for Visual Studio
-*.csproj merge=union
-*.vbproj merge=union
-*.fsproj merge=union
-*.dbproj merge=union 
-*.sln text eol=crlf merge=union
 *.suo 	-text -diff
 *.snk 	-text -diff
 *.cub 	-text -diff


### PR DESCRIPTION
Remove `merge=union` from `.gitattribute` file to avoid auto-resolving conflicts by taking changes from both sides.