### PR TITLE
Prevent conflict exception

### DIFF
--- a/src/Transport/DelayDelivery/LockManager.cs
+++ b/src/Transport/DelayDelivery/LockManager.cs
@@ -66,6 +66,10 @@
                 catch (StorageException)
                 {
                 }
+                finally
+                {
+                    lease = null;
+                }
             }
         }
 

--- a/src/Transport/DelayDelivery/LockManager.cs
+++ b/src/Transport/DelayDelivery/LockManager.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
-    using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 
     // Provides a container lease based lock manager.
     class LockManager
@@ -36,6 +35,7 @@
                 catch (StorageException exception)
                     when (exception.RequestInformation.HttpStatusCode == (int) HttpStatusCode.Conflict)
                 {
+                    // someone else raced for the lease and got it
                     return false;
                 }
             }
@@ -45,8 +45,9 @@
                 return true;
             }
             catch (StorageException exception)
-                when (exception.RequestInformation.ErrorCode == BlobErrorCodeStrings.LeaseIdMismatchWithLeaseOperation)
+                when (exception.RequestInformation.HttpStatusCode == (int) HttpStatusCode.Conflict)
             {
+                // someone else raced for the lease and got it so we have to try to re-acquire it
                 lease = null;
                 return false;
             }


### PR DESCRIPTION
I was able to randomly reproduce the case when

```
exception.RequestInformation.ErrorCode == BlobErrorCodeStrings.LeaseIdMismatchWithLeaseOperation
```

was set. In all those cases `409` was also present. 

The stack trace we got from the customer

```
Microsoft.WindowsAzure.Storage.StorageException: The remote server returned an error: (409) Conflict. (Failed to fetch delayed messages from the storage) ---> System.Net.WebException: The remote server returned an error: (409) Conflict.

at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndExecuteAsync[T](System.IAsyncResult) in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\ClassLibraryCommon\Core\Executor\Executor.cs:line 50

at Microsoft.WindowsAzure.Storage.Core.Util.AsyncExtensions+<>c__DisplayClass4.<CreateCallbackVoid>b__3(System.IAsyncResult) in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\ClassLibraryCommon\Core\Util\AsyncExtensions.cs:line 115

at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()

at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)

at NServiceBus.Azure.Transports.WindowsAzureStorageQueues.DelayDelivery.LockManager+<TryLockOrRenew>d__5.MoveNext() in C:\BuildAgent\work\e471362c5647d835\src\Transport\DelayDelivery\LockManager.cs:line 45

at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()

at NServiceBus.Azure.Transports.WindowsAzureStorageQueues.DelayDelivery.DelayedMessagesPoller+<InnerPoll>d__17.MoveNext() in C:\BuildAgent\work\e471362c5647d835\src\Transport\DelayDelivery\DelayedMessagesPoller.cs:line 96

at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()

at NServiceBus.Azure.Transports.WindowsAzureStorageQueues.DelayDelivery.DelayedMessagesPoller+<Poll>d__16.MoveNext() in C:\BuildAgent\work\e471362c5647d835\src\Transport\DelayDelivery\DelayedMessagesPoller.cs:line 68

at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)

at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)

at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run()

at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c__DisplayClass4_0.<OutputAsyncCausalityEvents>b__0()

at System.Runtime.CompilerServices.TaskAwaiter+<>c__DisplayClass11_0.<OutputWaitEtwEvents>b__0()

at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(System.Action, Boolean, System.Threading.Tasks.Task ByRef)

at System.Threading.Tasks.Task.FinishContinuations()

at System.Threading.Tasks.Task.Finish(Boolean)

at System.Threading.Tasks.Task`1.TrySetException(System.Object)

at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetException(System.Exception)

at NServiceBus.Azure.Transports.WindowsAzureStorageQueues.DelayDelivery.DelayedMessagesPoller+<InnerPoll>d__17.MoveNext() in C:\BuildAgent\work\e471362c5647d835\src\Transport\DelayDelivery\DelayedMessagesPoller.cs:line 96

at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)

at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)

at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run()

at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c__DisplayClass4_0.<OutputAsyncCausalityEvents>b__0()

at System.Runtime.CompilerServices.TaskAwaiter+<>c__DisplayClass11_0.<OutputWaitEtwEvents>b__0()

at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(System.Action, Boolean, System.Threading.Tasks.Task ByRef)

at System.Threading.Tasks.Task.FinishContinuations()

at System.Threading.Tasks.Task.Finish(Boolean)

at System.Threading.Tasks.Task`1.TrySetException(System.Object)

at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetException(System.Exception)

at NServiceBus.Azure.Transports.WindowsAzureStorageQueues.DelayDelivery.LockManager+<TryLockOrRenew>d__5.MoveNext() in C:\BuildAgent\work\e471362c5647d835\src\Transport\DelayDelivery\LockManager.cs:line 45

at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)

at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)

at System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run()

at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c__DisplayClass4_0.<OutputAsyncCausalityEvents>b__0()

at System.Runtime.CompilerServices.TaskAwaiter+<>c__DisplayClass11_0.<OutputWaitEtwEvents>b__0()

at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(System.Action, Boolean, System.Threading.Tasks.Task ByRef)

at System.Threading.Tasks.Task.FinishContinuations()

at System.Threading.Tasks.Task.Finish(Boolean)

at System.Threading.Tasks.Task`1.TrySetException(System.Object)

at System.Threading.Tasks.TaskCompletionSource`1.TrySetException(System.Exception)

at Microsoft.WindowsAzure.Storage.Core.Util.AsyncExtensions+<>c__DisplayClass4.<CreateCallbackVoid>b__3(System.IAsyncResult) in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\ClassLibraryCommon\Core\Util\AsyncExtensions.cs:line 115

at Microsoft.WindowsAzure.Storage.Core.Util.StorageCommandAsyncResult.OnComplete() in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\ClassLibraryCommon\Core\Util\StorageCommandAsyncResult.cs:line 195

at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndOperation[T](Microsoft.WindowsAzure.Storage.Core.Executor.ExecutionState`1[T]) in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\ClassLibraryCommon\Core\Executor\Executor.cs:line 511

at Microsoft.WindowsAzure.Storage.Core.Util.AsyncStreamCopier`1+<>c__DisplayClass1.<StartCopyStream>b__0(System.Threading.Tasks.Task) in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\ClassLibraryCommon\Core\Util\AsyncStreamCopier.cs:line 143

at System.Threading.Tasks.Task.Execute()

at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)

at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)

at System.Threading.Tasks.Task.ExecuteWithThreadLocal(System.Threading.Tasks.Task ByRef)

at System.Threading.Tasks.Task.ExecuteEntry(Boolean)

at System.Threading.ThreadPoolWorkQueue.Dispatch()

--- End of inner exception stack trace ---

at Microsoft.WindowsAzure.Storage.Shared.Protocol.HttpResponseParsers.ProcessExpectedStatusCodeNoException[T](System.Net.HttpStatusCode, System.Net.HttpStatusCode, T, Microsoft.WindowsAzure.Storage.Core.Executor.StorageCommandBase`1[T], System.Exception) in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\Common\Shared\Protocol\HttpResponseParsers.Common.cs:line 50

at Microsoft.WindowsAzure.Storage.Blob.CloudBlobContainer.<RenewLeaseImpl>b__12(Microsoft.WindowsAzure.Storage.Core.Executor.RESTCommand`1[Microsoft.WindowsAzure.Storage.Core.NullType], System.Net.HttpWebResponse, System.Exception, Microsoft.WindowsAzure.Storage.OperationContext) in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\ClassLibraryCommon\Blob\CloudBlobContainer.cs:line 2389

at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.EndGetResponse[T](System.IAsyncResult) in c:\Program Files (x86)\Jenkins\workspace\release_dotnet_master\Lib\ClassLibraryCommon\Core\Executor\Executor.cs:line 299
```

seems to highlight a race when one poller tries to renew the lock while another has already acquired it (due to lease timeout). In those cases a 409 is also raised. Therefore checking for 409 is enough I think