### PR TITLE
Connection string handling

### DIFF
--- a/src/Tests/When_ConnectionStringValidator_is_used_with_cosmosdb_connection_string.cs
+++ b/src/Tests/When_ConnectionStringValidator_is_used_with_cosmosdb_connection_string.cs
@@ -1,19 +1,17 @@
 ﻿using System;
-using NServiceBus.Settings;
-using NServiceBus.Transport.AzureStorageQueues;
 using NUnit.Framework;
 
 namespace NServiceBus.Transport.AzureStorageQueues.Tests
 {
     [TestFixture]
-    public class When_using_cosmos_db_connection_string
+    public class When_ConnectionStringValidator_is_used_with_cosmosdb_connection_string
     {
         [Test]
         public void Should_throw()
         {
             var connectionString = "DefaultEndpointsProtocol=https;AccountName=abcdefg;AccountKey=kIHCqw2jaATPAaayJoiJwPEYZITu2Ic5p4rDyJ5OhU97aub4IzoNCuTbuWgeaY29zQcw==;TableEndpoint=https://abcdefg.table.cosmos.azure.com:443/;";
 
-            Assert.Throws<Exception>(() => new AzureStorageQueueInfrastructure(new SettingsHolder(), connectionString));
+            Assert.Throws<Exception>(() => ConnectionStringValidator.ThrowIfPremiumEndpointConnectionString(connectionString));
         }
     }
 }

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -38,8 +38,6 @@
 
                 if (!settings.TryGet<IProvideBlobServiceClient>(out var blobServiceClientProvider))
                 {
-                    ThrowIfPremiumEndpointConnectionString();
-
                     blobServiceClientProvider = new BlobServiceClientProvidedByConnectionString(this.connectionString);
                 }
 
@@ -99,22 +97,6 @@
             });
         }
 
-        private void ThrowIfPremiumEndpointConnectionString()
-        {
-            if (IsPremiumEndpoint(this.connectionString))
-            {
-                throw new Exception(
-                    $"When configuring {nameof(AzureStorageQueueTransport)} with a single connection string, only Azure Storage connection can be used. See documentation for alternative options to configure the transport.");
-            }
-        }
-
-        // Adopted from Cosmos DB Table API SDK that uses similar approach to change the underlying execution
-        static bool IsPremiumEndpoint(string connectionString)
-        {
-            var lowerInvariant = connectionString.ToLowerInvariant();
-            return lowerInvariant.Contains("https://localhost") || lowerInvariant.Contains(".table.cosmosdb.") || lowerInvariant.Contains(".table.cosmos.");
-        }
-
         public override IEnumerable<Type> DeliveryConstraints => supportedDeliveryConstraints;
         public override TransportTransactionMode TransactionMode { get; } = TransportTransactionMode.ReceiveOnly;
         public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
@@ -154,8 +136,6 @@
 
             if (!settings.TryGet<IProvideQueueServiceClient>(out var queueServiceClientProvider))
             {
-                ThrowIfPremiumEndpointConnectionString();
-
                 queueServiceClientProvider = new QueueServiceClientProvidedByConnectionString(connectionString);
             }
 
@@ -209,8 +189,6 @@
         {
             if (!settings.TryGet<IProvideQueueServiceClient>(out var queueServiceClientProvider))
             {
-                ThrowIfPremiumEndpointConnectionString();
-
                 queueServiceClientProvider = new QueueServiceClientProvidedByConnectionString(connectionString);
             }
 

--- a/src/Transport/AzureStorageQueueTransport.cs
+++ b/src/Transport/AzureStorageQueueTransport.cs
@@ -17,7 +17,7 @@ namespace NServiceBus
         internal const string SerializerSettingsKey = "MainSerializer";
 
         /// <inheritdoc cref="RequiresConnectionString"/>
-        public override bool RequiresConnectionString { get; } = true;
+        public override bool RequiresConnectionString { get; } = false;
 
         /// <inheritdoc cref="ExampleConnectionStringForErrorMessage"/>
         public override string ExampleConnectionStringForErrorMessage { get; } =

--- a/src/Transport/Config/BlobServiceClientProvidedByConnectionString.cs
+++ b/src/Transport/Config/BlobServiceClientProvidedByConnectionString.cs
@@ -6,6 +6,8 @@
     {
         public BlobServiceClientProvidedByConnectionString(string connectionString)
         {
+            ConnectionStringValidator.ThrowIfPremiumEndpointConnectionString(connectionString);
+
             Client = new BlobServiceClient(connectionString);
         }
 

--- a/src/Transport/Config/QueueServiceClientProvidedByConnectionString.cs
+++ b/src/Transport/Config/QueueServiceClientProvidedByConnectionString.cs
@@ -6,6 +6,8 @@
     {
         public QueueServiceClientProvidedByConnectionString(string connectionString)
         {
+            ConnectionStringValidator.ThrowIfPremiumEndpointConnectionString(connectionString);
+
             Client = new QueueServiceClient(connectionString);
         }
 

--- a/src/Transport/ConnectionStringValidator.cs
+++ b/src/Transport/ConnectionStringValidator.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Transport.AzureStorageQueues
+{
+    using System;
+
+    static class ConnectionStringValidator
+    {
+        public static void ThrowIfPremiumEndpointConnectionString(string connectionString)
+        {
+            if (IsPremiumEndpoint(connectionString))
+            {
+                throw new Exception($"When configuring {nameof(AzureStorageQueueTransport)} with a single connection string, only Azure Storage connection can be used. See documentation for alternative options to configure the transport.");
+            }
+        }
+
+        // Adopted from Cosmos DB Table API SDK that uses similar approach to change the underlying execution
+        static bool IsPremiumEndpoint(string connectionString)
+        {
+            var lowerInvariant = connectionString.ToLowerInvariant();
+            return lowerInvariant.Contains("https://localhost") || lowerInvariant.Contains(".table.cosmosdb.") || lowerInvariant.Contains(".table.cosmos.");
+        }
+    }
+}


### PR DESCRIPTION
The connection string is becoming optional with the introduction of clients. Since it cannot be deprecated, we still need to support it yet throw when an attempt to use a Cosmos DB Table API connection string is used for either queue or blob client.