### PR TITLE
respect cancellation token in circuit breaker

### DIFF
--- a/src/Transport/RepeatedFailuresOverTimeCircuitBreaker.cs
+++ b/src/Transport/RepeatedFailuresOverTimeCircuitBreaker.cs
@@ -45,7 +45,7 @@
                 Logger.WarnFormat("The circuit breaker for {0} is now in the armed state", name);
             }
 
-            return Task.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
+            return Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
         }
 
         void CircuitBreakerTriggered(object state)


### PR DESCRIPTION
Similar to https://github.com/Particular/NServiceBus.SqlServer/pull/840.

Less of a concern here since the delay is only 1 second, but I don't see a reason for not respecting the token. The only call is [here](https://github.com/Particular/NServiceBus.AzureStorageQueues/blob/3ec463e0a34f5d2959bea62d511a20c3f4b5f26a/src/Transport/MessageReceiver.cs#L166), which is a regular (exception throwing) method, so no changes are required there.