### PR TITLE
Simplify delayed delivery

### DIFF
--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -84,23 +84,22 @@
 
             var delayedDeliveryIsEnabled = NativeDelayedDeliveryIsEnabled();
 
-            // This call mutates settings holder and should not be invoked more than once. This value is used for Diagnostics Section upon startup as well.
-            var delayedDeliveryTableName = GetDelayedDeliveryTableName(settings);
-
-            nativeDelayedDelivery = new NativeDelayDelivery(
-                cloudTableClientProvider,
-                blobServiceClientProvider,
-                delayedDeliveryTableName,
-                delayedDeliveryIsEnabled,
-                settings.ErrorQueueAddress(),
-                GetRequiredTransactionMode(),
-                maximumWaitTime,
-                peekInterval,
-                BuildDispatcher);
-
             object delayedDelivery;
             if (delayedDeliveryIsEnabled)
             {
+                // This call mutates settings holder and should not be invoked more than once. This value is used for Diagnostics Section upon startup as well.
+                var delayedDeliveryTableName = GetDelayedDeliveryTableName(settings);
+
+                nativeDelayedDelivery = new NativeDelayDelivery(
+                    cloudTableClientProvider,
+                    blobServiceClientProvider,
+                    delayedDeliveryTableName,
+                    settings.ErrorQueueAddress(),
+                    GetRequiredTransactionMode(),
+                    maximumWaitTime,
+                    peekInterval,
+                    BuildDispatcher);
+
                 delayedDelivery = new
                 {
                     NativeDelayedDeliveryIsEnabled = true,
@@ -110,6 +109,8 @@
             }
             else
             {
+                nativeDelayedDelivery = new DisabledNativeDelayDelivery();
+
                 delayedDelivery = new
                 {
                     NativeDelayedDeliveryIsEnabled = false,

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -368,7 +368,7 @@
         IProvideCloudTableClient cloudTableClientProvider;
         IProvideBlobServiceClient blobServiceClientProvider;
         IProvideQueueServiceClient queueServiceClientProvider;
-        NativeDelayDelivery nativeDelayedDelivery;
+        INativeDelayDelivery nativeDelayedDelivery;
         QueueAddressGenerator addressGenerator;
         ISubscriptionStore subscriptionStore;
         AzureStorageAddressingSettings addressing;

--- a/src/Transport/DelayDelivery/DisabledNativeDelayDelivery.cs
+++ b/src/Transport/DelayDelivery/DisabledNativeDelayDelivery.cs
@@ -1,0 +1,25 @@
+﻿namespace NServiceBus.Transport.AzureStorageQueues
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    class DisabledNativeDelayDelivery : INativeDelayDelivery
+    {
+        public Task Start() => Task.CompletedTask;
+
+        public Task Stop() => Task.CompletedTask;
+
+        public Task<bool> ShouldDispatch(UnicastTransportOperation operation, CancellationToken cancellationToken)
+        {
+            var constraints = operation.DeliveryConstraints;
+            var delay = NativeDelayDelivery.GetVisibilityDelay(constraints);
+            if (delay != null)
+            {
+                throw new Exception("Cannot delay delivery of messages when delayed delivery has been disabled. Remove the 'endpointConfiguration.UseTransport<AzureStorageQueues>.DelayedDelivery().DisableDelayedDelivery()' configuration to re-enable delayed delivery.");
+            }
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/src/Transport/DelayDelivery/INativeDelayDelivery.cs
+++ b/src/Transport/DelayDelivery/INativeDelayDelivery.cs
@@ -1,0 +1,12 @@
+﻿namespace NServiceBus.Transport.AzureStorageQueues
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    interface INativeDelayDelivery
+    {
+        Task Start();
+        Task Stop();
+        Task<bool> ShouldDispatch(UnicastTransportOperation operation, CancellationToken cancellationToken);
+    }
+}

--- a/src/Transport/DelayDelivery/NativeDelayDelivery.cs
+++ b/src/Transport/DelayDelivery/NativeDelayDelivery.cs
@@ -14,7 +14,7 @@
     using global::Azure.Storage.Blobs;
     using Logging;
 
-    class NativeDelayDelivery
+    class NativeDelayDelivery : INativeDelayDelivery
     {
         public NativeDelayDelivery(
             IProvideCloudTableClient cloudTableClientProvider,

--- a/src/Transport/DelayDelivery/NativeDelayDelivery.cs
+++ b/src/Transport/DelayDelivery/NativeDelayDelivery.cs
@@ -20,7 +20,6 @@
             IProvideCloudTableClient cloudTableClientProvider,
             IProvideBlobServiceClient blobServiceClientProvider,
             string delayedMessagesTableName,
-            bool delayedDeliveryEnabled,
             string errorQueueAddress,
             TransportTransactionMode transactionMode,
             TimeSpan maximumWaitTime,
@@ -30,7 +29,6 @@
             this.delayedMessagesTableName = delayedMessagesTableName;
             cloudTableClient = cloudTableClientProvider.Client;
             blobServiceClient = blobServiceClientProvider.Client;
-            this.delayedDeliveryEnabled = delayedDeliveryEnabled;
             this.errorQueueAddress = errorQueueAddress;
             isAtMostOnce = transactionMode == TransportTransactionMode.None;
             this.maximumWaitTime = maximumWaitTime;
@@ -40,31 +38,23 @@
 
         public async Task Start()
         {
-            if (delayedDeliveryEnabled)
-            {
-                Logger.Debug("Starting delayed delivery poller");
+            Logger.Debug("Starting delayed delivery poller");
 
-                Table = cloudTableClient.GetTableReference(delayedMessagesTableName);
-                await Table.CreateIfNotExistsAsync().ConfigureAwait(false);
+            Table = cloudTableClient.GetTableReference(delayedMessagesTableName);
+            await Table.CreateIfNotExistsAsync().ConfigureAwait(false);
 
-                nativeDelayedMessagesCancellationSource = new CancellationTokenSource();
-                poller = new DelayedMessagesPoller(Table, blobServiceClient, errorQueueAddress, isAtMostOnce, dispatcherFactory(), new BackoffStrategy(peekInterval, maximumWaitTime));
-                poller.Start(nativeDelayedMessagesCancellationSource.Token);
-            }
+            nativeDelayedMessagesCancellationSource = new CancellationTokenSource();
+            poller = new DelayedMessagesPoller(Table, blobServiceClient, errorQueueAddress, isAtMostOnce, dispatcherFactory(), new BackoffStrategy(peekInterval, maximumWaitTime));
+            poller.Start(nativeDelayedMessagesCancellationSource.Token);
         }
 
         public Task Stop()
         {
-            if (delayedDeliveryEnabled)
-            {
-                Logger.Debug("Stopping delayed delivery poller");
+            Logger.Debug("Stopping delayed delivery poller");
 
-                nativeDelayedMessagesCancellationSource?.Cancel();
+            nativeDelayedMessagesCancellationSource?.Cancel();
 
-                return poller != null ? poller.Stop() : Task.CompletedTask;
-            }
-
-            return Task.CompletedTask;
+            return poller != null ? poller.Stop() : Task.CompletedTask;
         }
 
         public async Task<bool> ShouldDispatch(UnicastTransportOperation operation, CancellationToken cancellationToken)
@@ -73,11 +63,6 @@
             var delay = GetVisibilityDelay(constraints);
             if (delay != null)
             {
-                if (delayedDeliveryEnabled == false)
-                {
-                    throw new Exception("Cannot delay delivery of messages when delayed delivery has been disabled. Remove the 'endpointConfiguration.UseTransport<AzureStorageQueues>.DelayedDelivery().DisableDelayedDelivery()' configuration to re-enable delayed delivery.");
-                }
-
                 if (FirstOrDefault<DiscardIfNotReceivedBefore>(constraints) != null)
                 {
                     throw new Exception($"Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of type '{operation.Message.Headers[Headers.EnclosedMessageTypes]}'.");
@@ -108,7 +93,7 @@
             return StartupCheckResult.Success;
         }
 
-        static TimeSpan? GetVisibilityDelay(List<DeliveryConstraint> constraints)
+        internal static TimeSpan? GetVisibilityDelay(List<DeliveryConstraint> constraints)
         {
             var doNotDeliverBefore = FirstOrDefault<DoNotDeliverBefore>(constraints);
             if (doNotDeliverBefore != null)
@@ -168,7 +153,6 @@
         DelayedMessagesPoller poller;
         CancellationTokenSource nativeDelayedMessagesCancellationSource;
         readonly BlobServiceClient blobServiceClient;
-        readonly bool delayedDeliveryEnabled;
         readonly string errorQueueAddress;
         readonly bool isAtMostOnce;
         readonly TimeSpan maximumWaitTime;


### PR DESCRIPTION
Simplifies the delayed delivery code by extracting all of the disabled behavior into it's own class and only instantiating the original if it is needed. This allows us to avoid creating the blob service client unless it is needed.