### PR TITLE
Remove usage of obsoleted address translation method

### DIFF
--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -1,16 +1,15 @@
 ﻿namespace NServiceBus.Transport.AzureStorageQueues
 {
-    using System.Collections.ObjectModel;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Transport;
 
     class AzureStorageQueueInfrastructure : TransportInfrastructure
     {
-        public AzureStorageQueueInfrastructure(AzureStorageQueueTransport transport, Dispatcher dispatcher, ReadOnlyDictionary<string, IMessageReceiver> receivers, NativeDelayedDeliveryProcessor nativeDelayedDeliveryProcessor)
+        public AzureStorageQueueInfrastructure(AzureStorageQueueTransport transport, Dispatcher dispatcher, NativeDelayedDeliveryProcessor nativeDelayedDeliveryProcessor)
         {
             Dispatcher = dispatcher;
-            Receivers = receivers;
             this.transport = transport;
             this.nativeDelayedDeliveryProcessor = nativeDelayedDeliveryProcessor;
         }
@@ -18,6 +17,41 @@
         public override Task Shutdown(CancellationToken cancellationToken = default)
         {
             return nativeDelayedDeliveryProcessor.Stop(cancellationToken);
+        }
+
+        public void BuildReceivers(ReceiveSettings[] receiveSettings, HostSettings hostSettings,
+            MessageWrapperSerializer serializer, ISubscriptionStore subscriptionStore, IQueueServiceClientProvider queueServiceClientProvider, QueueAddressGenerator queueAddressGenerator)
+        {
+            var receivers = new Dictionary<string, IMessageReceiver>();
+
+            foreach (var receiveSetting in receiveSettings)
+            {
+                var unwrapper = transport.MessageUnwrapper != null
+                    ? (IMessageEnvelopeUnwrapper)new UserProvidedEnvelopeUnwrapper(transport.MessageUnwrapper)
+                    : new DefaultMessageEnvelopeUnwrapper(serializer);
+
+                var receiveAddress = ToTransportAddress(receiveSetting.ReceiveAddress);
+
+                var subscriptionManager = new SubscriptionManager(subscriptionStore, hostSettings.Name, receiveAddress);
+
+                var receiver = new AzureMessageQueueReceiver(unwrapper, queueServiceClientProvider, queueAddressGenerator, receiveSetting.PurgeOnStartup, transport.MessageInvisibleTime);
+
+                receivers.Add(receiveSetting.Id,
+                    new MessageReceiver(
+                        receiveSetting.Id,
+                        transport.TransportTransactionMode,
+                        receiver,
+                        subscriptionManager,
+                        receiveAddress,
+                        receiveSetting.ErrorQueue,
+                        hostSettings.CriticalErrorAction,
+                        transport.DegreeOfReceiveParallelism,
+                        transport.ReceiverBatchSize,
+                        transport.MaximumWaitTimeWhenIdle,
+                        transport.PeekInterval));
+            }
+
+            Receivers = receivers;
         }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Transport/AzureStorageQueueTransport.cs
+++ b/src/Transport/AzureStorageQueueTransport.cs
@@ -2,7 +2,6 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
@@ -360,35 +359,6 @@ namespace NServiceBus
             var serializerFactory = definition.Configure(settings);
             var serializer = serializerFactory(mapper);
             return serializer;
-        }
-
-        (string Id, IMessageReceiver Receiver) BuildReceiver(HostSettings hostSettings, ReceiveSettings receiveSettings,
-            MessageWrapperSerializer serializer, ISubscriptionStore subscriptionStore)
-        {
-            var unwrapper = MessageUnwrapper != null
-                ? (IMessageEnvelopeUnwrapper)new UserProvidedEnvelopeUnwrapper(MessageUnwrapper)
-                : new DefaultMessageEnvelopeUnwrapper(serializer);
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            var receiveAddress = ToTransportAddress(receiveSettings.ReceiveAddress);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            var subscriptionManager = new SubscriptionManager(subscriptionStore, hostSettings.Name, receiveAddress);
-
-            var receiver = new AzureMessageQueueReceiver(unwrapper, queueServiceClientProvider, GetQueueAddressGenerator(), receiveSettings.PurgeOnStartup, MessageInvisibleTime);
-
-            return (receiveSettings.Id, new MessageReceiver(
-                receiveSettings.Id,
-                TransportTransactionMode,
-                receiver,
-                subscriptionManager,
-                receiveAddress,
-                receiveSettings.ErrorQueue,
-                hostSettings.CriticalErrorAction,
-                DegreeOfReceiveParallelism,
-                ReceiverBatchSize,
-                MaximumWaitTimeWhenIdle,
-                PeekInterval));
         }
 
         QueueAddressGenerator GetQueueAddressGenerator()


### PR DESCRIPTION
The current base PR still uses ToTransportAddress from the TransportDefinition to create the receivers. When the next TF will go and remove the implementation in TransportDefiniton this will cause problems because the receivers are built before the infrastructure.

This PR moves the building of the receivers inside the Infrastructure so that the usage of the address translation is only used once the infrastructure type has been created.

Not sure it's worthwhile doing this change, because it looks like ToTransportAddress still requires some stuff from TransportDefinition internally anyway, which is heavily used within the Initialze method, so it won't be that easy to remove other ongoing address translation from TransportDefinition anyway.