### PR TITLE
Backport msg size limit 11.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ The Azure Storage Queues transport for NServiceBus enables the use of the Azure 
 ## How to test locally
 
 To run the tests locally, add a new environment variable `AzureStorageQueueTransport_ConnectionString` containing a connection string to your Azure storage account or the connection string `UseDevelopmentStorage=true` to use the [Azurite emulator](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite) (ensure it is started before you run the tests).
+
+Additionally, [Microsoft Azure Storage Explorer](https://azure.microsoft.com/en-us/products/storage/storage-explorer) is an useful free tool that can allow you to view and manage the contents of the Azurite emulator as well as Azure Storage accounts in the cloud.

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,13 @@
+# Azurite queue
+__queuestorage__
+__azurite_db_queue__.json
+__azurite_db_queue_extent__.json
+
+# Azurite blob
+__blobstorage__
+__azurite_db_blob__.json
+__azurite_db_blob_extent__.json
+
+# Azurite table
+__azurite_db_table__.json
+__azurite_db_table_extent__.json

--- a/src/AcceptanceTests/Receiving/When_receiving_large_message.cs
+++ b/src/AcceptanceTests/Receiving/When_receiving_large_message.cs
@@ -1,0 +1,179 @@
+namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Azure.Transports.WindowsAzureStorageQueues;
+    using global::Azure.Storage.Queues;
+    using global::Newtonsoft.Json;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Faults;
+    using NUnit.Framework;
+
+    public class When_receiving_large_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_consume_it_without_the_error_headers_when_message_size_very_close_to_limit()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<Receiver>(b =>
+                {
+                    b.When((bus, c) =>
+                    {
+                        var connectionString = Testing.Utilities.GetEnvConfiguredConnectionString();
+                        var queueClient = new QueueClient(connectionString, "receivinglargemessage-receiver");
+
+                        //This value is fine tuned to ensure adding the 2 error headers make the message too large
+                        string contentCloseToLimits = new string('x', (35 * 1024) + 425);
+
+                        var message = new MyMessage { SomeProperty = contentCloseToLimits, };
+
+                        var messageSerialized = JsonConvert.SerializeObject(message, typeof(MyMessage), Formatting.Indented, new JsonSerializerSettings());
+
+                        string id = Guid.NewGuid().ToString();
+                        var wrapper = new MessageWrapper
+                        {
+                            Id = id,
+                            Body = Encoding.UTF8.GetBytes(messageSerialized),
+                            Headers = new Dictionary<string, string>
+                            {
+                                { Headers.EnclosedMessageTypes, $"{typeof(MyMessage).AssemblyQualifiedName}" },
+                                { Headers.MessageId, id },
+                                { Headers.CorrelationId, id },
+                                {TestIndependence.HeaderName, c.TestRunId.ToString()}
+                            }
+                        };
+
+                        var wrapperSerialized = JsonConvert.SerializeObject(wrapper, typeof(MessageWrapper), Formatting.Indented, new JsonSerializerSettings());
+
+                        var base64Encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(wrapperSerialized));
+
+                        return queueClient.SendMessageAsync(base64Encoded);
+                    }).DoNotFailOnErrorMessages();
+                })
+                .WithEndpoint<ErrorSpy>()
+                .Done(c => c.MessageMovedToTheErrorQueue)
+                .Run();
+
+            Assert.IsFalse(ctx.IsFailedQHeaderPresent, "IsFailedQHeaderPresent");
+            Assert.IsFalse(ctx.IsExceptionTypeHeaderPresent, "IsExceptionTypeHeaderPresent");
+        }
+
+        [Test]
+        public async Task Should_consume_it_with_only_two_error_headers_when_message_size_close_to_limit()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<Receiver>(b =>
+                {
+                    b.When((bus, c) =>
+                    {
+                        var connectionString = Testing.Utilities.GetEnvConfiguredConnectionString();
+                        var queueClient = new QueueClient(connectionString, "receivinglargemessage-receiver");
+
+                        string contentCloseToLimits = new string('x', (35 * 1024) + 400);
+
+                        var message = new MyMessage { SomeProperty = contentCloseToLimits, };
+
+                        var messageSerialized = JsonConvert.SerializeObject(message, typeof(MyMessage), Formatting.Indented, new JsonSerializerSettings());
+
+                        string id = Guid.NewGuid().ToString();
+                        var wrapper = new MessageWrapper
+                        {
+                            Id = id,
+                            Body = Encoding.UTF8.GetBytes(messageSerialized),
+                            Headers = new Dictionary<string, string>
+                            {
+                         { Headers.EnclosedMessageTypes, $"{typeof(MyMessage).AssemblyQualifiedName}" },
+                         { Headers.MessageId, id },
+                         { Headers.CorrelationId, id },
+                         {TestIndependence.HeaderName, c.TestRunId.ToString()}
+                            }
+                        };
+
+                        var wrapperSerialized = JsonConvert.SerializeObject(wrapper, typeof(MessageWrapper), Formatting.Indented, new JsonSerializerSettings());
+
+                        var base64Encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(wrapperSerialized));
+
+                        return queueClient.SendMessageAsync(base64Encoded);
+                    }).DoNotFailOnErrorMessages();
+                })
+                .WithEndpoint<ErrorSpy>()
+                .Done(c => c.MessageMovedToTheErrorQueue)
+                .Run();
+
+            Assert.IsTrue(ctx.IsFailedQHeaderPresent, "IsFailedQHeaderPresent");
+            Assert.IsTrue(ctx.IsExceptionTypeHeaderPresent, "IsExceptionTypeHeaderPresent");
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageMovedToTheErrorQueue { get; set; }
+            public bool IsFailedQHeaderPresent { get; set; }
+            public bool IsExceptionTypeHeaderPresent { get; set; }
+
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver() => EndpointSetup<DefaultServer>(c =>
+            {
+                c.UseSerialization<NewtonsoftJsonSerializer>();
+                c.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(ErrorSpy)));
+            });
+
+            public class MyHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+        }
+
+        class ErrorSpy : EndpointConfigurationBuilder
+        {
+            public ErrorSpy() => EndpointSetup<DefaultServer>(config =>
+            {
+                config.UseSerialization<NewtonsoftJsonSerializer>();
+                config.LimitMessageProcessingConcurrencyTo(1);
+            });
+
+            class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    if (context.MessageHeaders.TryGetValue(TestIndependence.HeaderName, out var testRunId)
+                        && testRunId == testContext.TestRunId.ToString())
+                    {
+                        testContext.MessageMovedToTheErrorQueue = true;
+                    }
+                    if (context.MessageHeaders.ContainsKey(FaultsHeaderKeys.FailedQ)
+                        && testRunId == testContext.TestRunId.ToString())
+                    {
+                        testContext.IsFailedQHeaderPresent = true;
+                    }
+                    if (context.MessageHeaders.ContainsKey("NServiceBus.ExceptionInfo.ExceptionType")
+                        && testRunId == testContext.TestRunId.ToString())
+                    {
+                        testContext.IsExceptionTypeHeaderPresent = true;
+                    }
+
+                    return Task.CompletedTask;
+                }
+
+                readonly Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+            public string SomeProperty { get; set; }
+        }
+    }
+}

--- a/src/Transport/AzureMessageQueueReceiver.cs
+++ b/src/Transport/AzureMessageQueueReceiver.cs
@@ -10,11 +10,12 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
     class AzureMessageQueueReceiver
     {
-        public AzureMessageQueueReceiver(IMessageEnvelopeUnwrapper unwrapper, IQueueServiceClientProvider queueServiceClientProvider, QueueAddressGenerator addressGenerator, bool purgeOnStartup, TimeSpan messageInvisibleTime)
+        public AzureMessageQueueReceiver(IMessageEnvelopeUnwrapper unwrapper, IQueueServiceClientProvider queueServiceClientProvider, QueueAddressGenerator addressGenerator, MessageWrapperSerializer serializer, bool purgeOnStartup, TimeSpan messageInvisibleTime)
         {
             this.unwrapper = unwrapper;
             queueServiceClient = queueServiceClientProvider.Client;
             this.addressGenerator = addressGenerator;
+            this.serializer = serializer;
             PurgeOnStartup = purgeOnStartup;
             MessageInvisibleTime = messageInvisibleTime;
         }
@@ -56,7 +57,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
             foreach (var rawMessage in rawMessages)
             {
-                receivedMessages.Add(new MessageRetrieved(unwrapper, rawMessage, inputQueue, errorQueue));
+                receivedMessages.Add(new MessageRetrieved(unwrapper, serializer, rawMessage, inputQueue, errorQueue));
             }
 
             await backoffStrategy.OnBatch(receivedMessages.Count, cancellationToken).ConfigureAwait(false);
@@ -65,7 +66,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
         IMessageEnvelopeUnwrapper unwrapper;
 
         QueueAddressGenerator addressGenerator;
-
+        MessageWrapperSerializer serializer;
         QueueClient inputQueue;
         QueueClient errorQueue;
         QueueServiceClient queueServiceClient;

--- a/src/Transport/AzureStorageQueueTransport.cs
+++ b/src/Transport/AzureStorageQueueTransport.cs
@@ -383,7 +383,7 @@ namespace NServiceBus
 
             var subscriptionManager = new SubscriptionManager(subscriptionStore, hostSettings.Name, receiveAddress);
 
-            var receiver = new AzureMessageQueueReceiver(unwrapper, queueServiceClientProvider, GetQueueAddressGenerator(), receiveSettings.PurgeOnStartup, MessageInvisibleTime);
+            var receiver = new AzureMessageQueueReceiver(unwrapper, queueServiceClientProvider, GetQueueAddressGenerator(), serializer, receiveSettings.PurgeOnStartup, MessageInvisibleTime);
 
             return (receiveSettings.Id, new MessageReceiver(
                 receiveSettings.Id,

--- a/src/Transport/Dispatcher.cs
+++ b/src/Transport/Dispatcher.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Transport.AzureStorageQueues
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -11,6 +10,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
     using global::Azure.Storage.Queues;
     using Logging;
     using NServiceBus.AzureStorageQueues;
+    using NServiceBus.Transport.AzureStorageQueues.Utils;
     using Transport;
     using Unicast.Queuing;
 
@@ -124,15 +124,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
         Task Send(MessageWrapper wrapper, QueueClient sendQueue, TimeSpan timeToBeReceived, CancellationToken cancellationToken)
         {
-            string base64String;
-
-            using (var stream = new MemoryStream())
-            {
-                serializer.Serialize(wrapper, stream);
-
-                var bytes = stream.ToArray();
-                base64String = Convert.ToBase64String(bytes);
-            }
+            string base64String = MessageWrapperHelper.ConvertToBase64String(wrapper, serializer);
 
             return sendQueue.SendMessageAsync(base64String, timeToLive: timeToBeReceived, cancellationToken: cancellationToken);
         }

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -129,17 +129,20 @@
                 throw;
             }
         }
+
         BinaryData ReWrap(MessageWrapper wrapper)
         {
             string base64String = MessageWrapperHelper.ConvertToBase64String(wrapper, serializer);
             return BinaryData.FromString(base64String);
         }
+
         readonly QueueClient inputQueue;
         readonly QueueMessage rawMessage;
         readonly QueueClient errorQueue;
         readonly IMessageEnvelopeUnwrapper unwrapper;
         readonly MessageWrapperSerializer serializer;
         MessageWrapper unwrappedMessage;
+
         static ILog Logger = LogManager.GetLogger<MessageRetrieved>();
     }
 

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -9,12 +9,15 @@
     using global::Azure.Storage.Queues;
     using global::Azure.Storage.Queues.Models;
     using Logging;
+    using NServiceBus.Faults;
+    using NServiceBus.Transport.AzureStorageQueues.Utils;
 
     class MessageRetrieved
     {
-        public MessageRetrieved(IMessageEnvelopeUnwrapper unwrapper, QueueMessage rawMessage, QueueClient inputQueue, QueueClient errorQueue)
+        public MessageRetrieved(IMessageEnvelopeUnwrapper unwrapper, MessageWrapperSerializer serializer, QueueMessage rawMessage, QueueClient inputQueue, QueueClient errorQueue)
         {
             this.unwrapper = unwrapper;
+            this.serializer = serializer;
             this.errorQueue = errorQueue;
             this.rawMessage = rawMessage;
             this.inputQueue = inputQueue;
@@ -32,20 +35,13 @@
             try
             {
                 Logger.DebugFormat("Unwrapping message with native ID: '{0}'", rawMessage.MessageId);
-                return unwrapper.Unwrap(rawMessage);
+                unwrappedMessage ??= unwrapper.Unwrap(rawMessage);
+                return unwrappedMessage;
             }
             catch (Exception ex)
             {
-                // When a CloudQueueMessage is retrieved and is en-queued directly, message's ID and PopReceipt are mutated.
-                // To be able to delete the original message, original message ID and PopReceipt have to be stored aside.
-                var messageId = rawMessage.MessageId;
-                var messagePopReceipt = rawMessage.PopReceipt;
-
-                await errorQueue.SendMessageAsync(rawMessage.MessageText, cancellationToken).ConfigureAwait(false);
-                // TODO: might not need this as the new SDK doesn't send a message by using the original message. Rather, copies the text only.
-                await inputQueue.DeleteMessageAsync(messageId, messagePopReceipt, cancellationToken).ConfigureAwait(false);
-
-                throw new SerializationException($"Failed to deserialize message envelope for message with id {messageId}. Make sure the configured serializer is used across all endpoints or configure the message wrapper serializer for this endpoint using the `SerializeMessageWrapperWith` extension on the transport configuration. Please refer to the Azure Storage Queue Transport configuration documentation for more details.", ex);
+                await MoveToErrorQueueWithoutModification(cancellationToken).ConfigureAwait(false);
+                throw new SerializationException($"Failed to deserialize message envelope for message with id {rawMessage.MessageId}. Make sure the configured serializer is used across all endpoints or configure the message wrapper serializer for this endpoint using the `SerializeMessageWrapperWith` extension on the transport configuration. Please refer to the Azure Storage Queue Transport configuration documentation for more details.", ex);
             }
         }
 
@@ -57,6 +53,49 @@
             AssertVisibilityTimeout();
 
             return inputQueue.DeleteMessageAsync(rawMessage.MessageId, rawMessage.PopReceipt, cancellationToken);
+        }
+        /// <summary>
+        /// Moves the message without expiry to the error queue
+        /// </summary>
+        public async Task MoveToErrorQueueWithoutModification(CancellationToken cancellationToken = default)
+        {
+            // When a CloudQueueMessage is retrieved and is en-queued directly, message's ID and PopReceipt are mutated.
+            // To be able to delete the original message, original message ID and PopReceipt have to be stored aside.
+            var messageId = rawMessage.MessageId;
+            var messagePopReceipt = rawMessage.PopReceipt;
+
+            await MoveToErrorQueue(messageId, messagePopReceipt, rawMessage.Body, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Moves the message without expiry to the error queue with minimal fault headers
+        /// </summary>
+        public async Task MoveToErrorQueueWithMinimalFaultHeaders(ErrorContext context, CancellationToken cancellationToken = default)
+        {
+            var unwrappedMessage = await Unwrap(cancellationToken).ConfigureAwait(false);
+
+            unwrappedMessage.Headers.Add(FaultsHeaderKeys.FailedQ, inputQueue.Name);
+            unwrappedMessage.Headers.Add("NServiceBus.ExceptionInfo.ExceptionType", context.Exception.GetType().FullName);
+
+            var body = ReWrap(unwrappedMessage);
+
+            await MoveToErrorQueue(rawMessage.MessageId, rawMessage.PopReceipt, body, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task MoveToErrorQueue(string messageId, string messagePopReceipt, BinaryData body, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await errorQueue.SendMessageAsync(body, timeToLive: TimeSpan.FromSeconds(-1), cancellationToken: cancellationToken).ConfigureAwait(false);
+                // TODO: might not need this as the new SDK doesn't send a message by using the original message. Rather, copies the text only.
+                await inputQueue.DeleteMessageAsync(messageId, messagePopReceipt, cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException e) when (e.Status == 413 && e.ErrorCode == "RequestBodyTooLarge")
+            {
+                Logger.WarnFormat($"Message with native ID `{messageId}` could not be moved to the error queue with additional headers because it was too large. Moving to the error queue as is.", e);
+
+                await MoveToErrorQueueWithoutModification(cancellationToken).ConfigureAwait(false);
+            }
         }
 
         void AssertVisibilityTimeout()
@@ -90,12 +129,17 @@
                 throw;
             }
         }
-
+        BinaryData ReWrap(MessageWrapper wrapper)
+        {
+            string base64String = MessageWrapperHelper.ConvertToBase64String(wrapper, serializer);
+            return BinaryData.FromString(base64String);
+        }
         readonly QueueClient inputQueue;
         readonly QueueMessage rawMessage;
         readonly QueueClient errorQueue;
         readonly IMessageEnvelopeUnwrapper unwrapper;
-
+        readonly MessageWrapperSerializer serializer;
+        MessageWrapper unwrappedMessage;
         static ILog Logger = LogManager.GetLogger<MessageRetrieved>();
     }
 

--- a/src/Transport/Utils/MessageWrapperHelper.cs
+++ b/src/Transport/Utils/MessageWrapperHelper.cs
@@ -1,0 +1,23 @@
+﻿namespace NServiceBus.Transport.AzureStorageQueues.Utils
+{
+    using System;
+    using System.IO;
+    using NServiceBus.Azure.Transports.WindowsAzureStorageQueues;
+
+    static class MessageWrapperHelper
+    {
+        public static string ConvertToBase64String(MessageWrapper wrapper, MessageWrapperSerializer serializer)
+        {
+            string base64String;
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(wrapper, stream);
+
+                var bytes = stream.ToArray();
+                base64String = Convert.ToBase64String(bytes);
+            }
+            return base64String;
+        }
+    }
+}


### PR DESCRIPTION
This PR is a manual back port of the following commits that were made to master

- Add Azurite gitignore to src (#1016)
- Make sure messages close to the size limit can be moved as is to the error queue (#1002)
- Mention Azure Storage Explorer (#1014)