### PR TITLE
Fix build warning

### DIFF
--- a/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
@@ -21,6 +21,9 @@
 
   <ItemGroup>
     <Compile Include="..\AcceptanceTests\BackwardsCompatibleQueueNameSanitizerForTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PkgNServiceBus_TransportTests_Sources)' != ''">
     <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\ExceptionExtensions.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR includes a fix for the build warnings from the compile items referencing the generated package path property.