### PR TITLE
handler execution exceeds consumer ack timeout

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.1.1" GeneratePathProperty="true" />

--- a/src/Tests/NServiceBus.Transport.AzureStorageQueues.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureStorageQueues.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NServiceBus" Version="9.1.1" />

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -23,40 +23,42 @@ namespace NServiceBus.Transport.AzureStorageQueues
             this.criticalErrorAction = criticalErrorAction;
         }
 
+
+
         public override async Task Receive(MessageRetrieved retrieved, MessageWrapper message, string receiveAddress, CancellationToken cancellationToken = default)
         {
             Logger.DebugFormat("Pushing received message (ID: '{0}') through pipeline.", message.Id);
-            var body = message.Body ?? Array.Empty<byte>();
-            var contextBag = new ContextBag();
+
             var nativeMessageId = retrieved.NativeMessageId;
             if (messagesToBeDeleted.TryGet(nativeMessageId, out _))
             {
                 await DeleteMessage(retrieved, nativeMessageId, cancellationToken).ConfigureAwait(false);
                 return;
             }
+            var messageProcessed = await InnerProcessMessage(retrieved, message, receiveAddress, nativeMessageId, cancellationToken).ConfigureAwait(false);
+
+            if (messageProcessed)
+            {
+                await DeleteMessage(retrieved, nativeMessageId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        async Task<bool> InnerProcessMessage(MessageRetrieved retrieved, MessageWrapper message, string receiveAddress, string nativeMessageId, CancellationToken cancellationToken = default)
+        {
+            var body = message.Body ?? Array.Empty<byte>();
+            var contextBag = new ContextBag();
+
             try
             {
-                var pushContext = new MessageContext(message.Id, new Dictionary<string, string>(message.Headers), body, new TransportTransaction(), receiveAddress, contextBag);
-                // var pushContext = new MessageContext(nativeMessageId, new Dictionary<string, string>(message.Headers), body, new TransportTransaction(), receiveAddress, contextBag);
+                var pushContext = new MessageContext(retrieved.NativeMessageId, new Dictionary<string, string>(message.Headers), body, new TransportTransaction(), receiveAddress, contextBag);
 
                 await onMessage(pushContext, cancellationToken).ConfigureAwait(false);
 
-                // await retrieved.Ack(cancellationToken).ConfigureAwait(false);
-                await DeleteMessage(retrieved, nativeMessageId, cancellationToken).ConfigureAwait(false);
             }
-            //catch (LeaseTimeoutException)
-            //{
-            //    // The lease has expired and cannot be used any longer to Ack or Nack the message.
-            //    // see original issue: https://github.com/Azure/azure-storage-net/issues/285
-            //    // throw;
-            //    //set visibility time out to zero and return back to queue
-            //    await retrieved.Nack(cancellationToken).ConfigureAwait(false);
-            //}
             catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
                 var deliveryAttempts = GetDeliveryAttempts(nativeMessageId);
-                var context = CreateErrorContext(message, ex, body, receiveAddress, contextBag, deliveryAttempts);
-
+                var context = CreateErrorContext(retrieved, message, ex, body, receiveAddress, contextBag, deliveryAttempts);
                 try
                 {
                     var errorHandleResult = await onError(context, cancellationToken).ConfigureAwait(false);
@@ -66,37 +68,30 @@ namespace NServiceBus.Transport.AzureStorageQueues
                         // For an immediate retry, the error is logged and the message is returned to the queue to preserve the DequeueCount.
                         // There is no in memory retry as scale-out scenarios would be handled improperly.
                         Logger.Warn("Azure Storage Queue transport failed pushing a message through pipeline. The message will be requeued", ex);
-                        //await retrieved.Nack(cancellationToken).ConfigureAwait(false);
                         await retrieved.ReturnMessageToQueue(cancellationToken).ConfigureAwait(false);
+                        return false;
                     }
                     else
                     {
-                        // Just acknowledge the message as it's handled by the core retry.
-                        await retrieved.Ack(cancellationToken).ConfigureAwait(false);
+                        //
                     }
                 }
                 catch (RequestFailedException e) when (e.Status == 413 && e.ErrorCode == "RequestBodyTooLarge")
                 {
-                    Logger.WarnFormat($"Message with native ID `{message.Id}` could not be moved to the error queue with additional headers because it was too large. Moving to the error queue as is.", e);
+                    Logger.WarnFormat($"Message with native ID `{nativeMessageId}` could not be moved to the error queue with additional headers because it was too large. Moving to the error queue as is.", e);
 
                     await retrieved.MoveToErrorQueueWithMinimalFaultHeaders(context, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception onErrorEx) when (!onErrorEx.IsCausedBy(cancellationToken))
                 {
-                    criticalErrorAction($"Failed to execute recoverability policy for message with native ID: `{message.Id}`", onErrorEx, cancellationToken);
+                    criticalErrorAction($"Failed to execute recoverability policy for message with native ID: `{nativeMessageId}`", onErrorEx, cancellationToken);
                     await retrieved.ReturnMessageToQueue(cancellationToken).ConfigureAwait(false);
-                    //try
-                    //{
-                    //    await retrieved.Nack(cancellationToken).ConfigureAwait(false);
-                    //}
-                    //catch (Exception nackEx) when (!nackEx.IsCausedBy(cancellationToken))
-                    //{
-                    //    Logger.Warn($"Failed to release visibility timeout after message with native ID `{message.Id}` failed to execute recoverability policy. The message will be available again when the visibility timeout expires.", nackEx);
-                    //}
+                    return false;
                 }
             }
-        }
 
+            return true;
+        }
 
         async Task DeleteMessage(MessageRetrieved retrieved, string nativeMessageId, CancellationToken cancellationToken = default)
         {

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -71,10 +71,6 @@ namespace NServiceBus.Transport.AzureStorageQueues
                         await retrieved.ReturnMessageToQueue(cancellationToken).ConfigureAwait(false);
                         return false;
                     }
-                    else
-                    {
-                        //
-                    }
                 }
                 catch (RequestFailedException e) when (e.Status == 413 && e.ErrorCode == "RequestBodyTooLarge")
                 {

--- a/src/Transport/MessageReceiver.cs
+++ b/src/Transport/MessageReceiver.cs
@@ -214,7 +214,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
             }
             catch (Exception ex)
             {
-                Logger.Warn("Azure Storage Queue transport failed pushing a message through pipeline", ex);
+                Logger.Error("Azure Storage Queue transport failed pushing a message through pipeline", ex);
             }
             finally
             {

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -57,8 +57,11 @@
 
             return inputQueue.DeleteMessageAsync(rawMessage.MessageId, rawMessage.PopReceipt, cancellationToken);
         }
+#pragma warning disable PS0018 // Do not add CancellationToken parameter - delete should not be cancellable
         public Task DeleteMessage(CancellationToken cancellationToken = default)
+#pragma warning restore PS0018 //  Do not add CancellationToken parameter - delete should not be cancellable
         {
+
             return inputQueue.DeleteMessageAsync(rawMessage.MessageId, rawMessage.PopReceipt, cancellationToken);
         }
         /// <summary>
@@ -139,8 +142,11 @@
                 throw;
             }
         }
+#pragma warning disable PS0018 //Cancellation token intentionally not passed because cancellation shouldn't stop messages from being returned to the queue
         public async Task ReturnMessageToQueue(CancellationToken cancellationToken = default)
+#pragma warning restore PS0018
         {
+
             try
             {
                 // the simplest solution to push the message back is to update its visibility timeout to 0 which is ok according to the API:

--- a/src/Transport/NServiceBus.Transport.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureStorageQueues.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.Data.Tables" Version="[12.8.3, 13.0.0)" />
     <PackageReference Include="Azure.Storage.Blobs" Version="[12.19.1, 13.0.0)" />
     <PackageReference Include="Azure.Storage.Queues" Version="[12.17.1, 13.0.0)" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/src/Transport/ReceiveStrategy.cs
+++ b/src/Transport/ReceiveStrategy.cs
@@ -25,9 +25,9 @@ namespace NServiceBus.Transport.AzureStorageQueues
             var context = new ErrorContext(ex, message.Headers, message.Id, body, new TransportTransaction(), Convert.ToInt32(retrieved.DequeueCount), receiveAddress, contextBag);
             return context;
         }
-        protected static ErrorContext CreateErrorContext(MessageWrapper message, Exception ex, byte[] body, string receiveAddress, ContextBag contextBag, int deliveryAttempts)
+        protected static ErrorContext CreateErrorContext(MessageRetrieved retrieved, MessageWrapper message, Exception ex, byte[] body, string receiveAddress, ContextBag contextBag, int deliveryAttempts)
         {
-            var context = new ErrorContext(ex, message.Headers, message.Id, body, new TransportTransaction(), deliveryAttempts, receiveAddress, contextBag);
+            var context = new ErrorContext(ex, message.Headers, retrieved.NativeMessageId, body, new TransportTransaction(), deliveryAttempts, receiveAddress, contextBag);
             return context;
         }
     }

--- a/src/Transport/ReceiveStrategy.cs
+++ b/src/Transport/ReceiveStrategy.cs
@@ -25,5 +25,10 @@ namespace NServiceBus.Transport.AzureStorageQueues
             var context = new ErrorContext(ex, message.Headers, message.Id, body, new TransportTransaction(), Convert.ToInt32(retrieved.DequeueCount), receiveAddress, contextBag);
             return context;
         }
+        protected static ErrorContext CreateErrorContext(MessageWrapper message, Exception ex, byte[] body, string receiveAddress, ContextBag contextBag, int deliveryAttempts)
+        {
+            var context = new ErrorContext(ex, message.Headers, message.Id, body, new TransportTransaction(), deliveryAttempts, receiveAddress, contextBag);
+            return context;
+        }
     }
 }

--- a/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.1.1" />


### PR DESCRIPTION
Draft fix for

- https://github.com/Particular/PlatformBugs/issues/1131

### Assumptions

- The fix follows similar code changes as for the issue 
  - https://github.com/Particular/NServiceBus.AmazonSQS/issues/1926
  - https://github.com/Particular/NServiceBus.AmazonSQS/pull/1861
- This applies only to "Receive Only"
- To maintain consistency with other transports (e.g., RabittMQ, SQS and ASQ) where a similar bug was addressed, this PR fix also uses LRU caching.

### ✔ What has been done

- An LRU (Least Recently Used) cache from the [BitFaster Caching](https://github.com/bitfaster/BitFaster.Caching) library that tracks the number of delivery attempts made per message and the message-ids that need to be deleted from the broker queue.



