### PR TITLE
Track messages that successfully completed the message or error pipeline but failed to get acknowledged due to expired leases

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
@@ -9,16 +9,19 @@
   <ItemGroup>
     <ProjectReference Include="..\Transport\NServiceBus.Transport.AzureStorageQueues.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.2" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.2" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Transport\NServiceBus.Transport.AzureStorageQueues.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />

--- a/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.2" GeneratePathProperty="true" />

--- a/src/AcceptanceTests/Receiving/When_message_visibility_expired.cs
+++ b/src/AcceptanceTests/Receiving/When_message_visibility_expired.cs
@@ -64,7 +64,13 @@
 
         class Receiver : EndpointConfigurationBuilder
         {
-            public Receiver() => EndpointSetup<DefaultServer>();
+            public Receiver() => EndpointSetup<DefaultServer>(c =>
+            {
+                var transport = c.ConfigureTransport<AzureStorageQueueTransport>();
+                // Explicitly setting the transport transaction mode to ReceiveOnly because the message 
+                // tracking only is implemented for this mode.
+                transport.TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
+            });
         }
 
         public class MyMessage : IMessage;

--- a/src/AcceptanceTests/Receiving/When_message_visibility_expired.cs
+++ b/src/AcceptanceTests/Receiving/When_message_visibility_expired.cs
@@ -1,0 +1,93 @@
+﻿namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using global::Azure.Storage.Queues;
+    using global::Azure.Storage.Queues.Models;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Testing;
+
+    public class When_message_visibility_expired : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_pipeline_successful()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<Receiver>(b => b.When((session, _) => session.SendLocal(new MyMessage())))
+                .Done(c => c.MessageId is not null && c.Logs.Any(l => WasMarkedAsSuccessfullyCompleted(l, c)))
+                .Run();
+
+            var items = ctx.Logs.Where(l => WasMarkedAsSuccessfullyCompleted(l, ctx)).ToArray();
+
+            Assert.That(items, Is.Not.Empty);
+        }
+
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_error_pipeline_handled_the_message()
+        {
+            var ctx = await Scenario.Define<Context>(c =>
+                {
+                    c.ShouldThrow = true;
+                })
+                .WithEndpoint<Receiver>(b =>
+                {
+                    b.DoNotFailOnErrorMessages();
+                    b.CustomConfig(c =>
+                    {
+                        var recoverability = c.Recoverability();
+                        recoverability.AddUnrecoverableException<InvalidOperationException>();
+                    });
+                    b.When((session, _) => session.SendLocal(new MyMessage()));
+                })
+                .Done(c => c.MessageId is not null && c.Logs.Any(l => WasMarkedAsSuccessfullyCompleted(l, c)))
+                .Run();
+
+            var items = ctx.Logs.Where(l => WasMarkedAsSuccessfullyCompleted(l, ctx)).ToArray();
+
+            Assert.That(items, Is.Not.Empty);
+        }
+
+        static bool WasMarkedAsSuccessfullyCompleted(ScenarioContext.LogItem l, Context c)
+            => l.Message.StartsWith($"Received message (ID: '{c.MessageId}') was marked as successfully completed");
+
+        class Context : ScenarioContext
+        {
+            public bool ShouldThrow { get; set; }
+
+            public string MessageId { get; set; }
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver() => EndpointSetup<DefaultServer>();
+        }
+
+        public class MyMessage : IMessage;
+
+        class MyMessageHandler(Context testContext) : IHandleMessages<MyMessage>
+        {
+            public async Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                var receiverQueue = BackwardsCompatibleQueueNameSanitizerForTests.Sanitize(Conventions.EndpointNamingConvention(typeof(Receiver)));
+                var queueClient = new QueueClient(Utilities.GetEnvConfiguredConnectionString(), receiverQueue);
+                var rawMessage = context.Extensions.Get<QueueMessage>();
+                // By setting the visibility timeout to a second, the message will be "immediately available" for retrieval again and effectively the message pump
+                // has lost the message visibility timeout because any ACK or NACK will be rejected by the storage service. The second was chosen
+                // to make sure there is some gap between the message is available again because the transport does heavy polling and concurrent fetching by default.
+                await queueClient.UpdateMessageAsync(rawMessage.MessageId, rawMessage.PopReceipt, visibilityTimeout: TimeSpan.FromSeconds(1), cancellationToken: context.CancellationToken);
+
+                testContext.MessageId = context.MessageId;
+
+                if (testContext.ShouldThrow)
+                {
+                    throw new InvalidOperationException("Simulated exception");
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/AtLeastOnceReceiveStrategyTests.cs
+++ b/src/Tests/AtLeastOnceReceiveStrategyTests.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
     using System;
     using System.Threading.Tasks;
     using Azure.Transports.WindowsAzureStorageQueues;
+    using global::Azure;
     using global::Azure.Storage.Queues.Models;
     using NUnit.Framework;
 
@@ -16,15 +17,15 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
             var onMessageCalled = 0;
             var onErrorCalled = 0;
 
-            var receiveStrategy = new AtLeastOnceReceiveStrategy((context, token) =>
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((_, _) =>
             {
                 onMessageCalled++;
                 return Task.CompletedTask;
-            }, (context, token) =>
+            }, (_, _) =>
             {
                 onErrorCalled++;
                 return Task.FromResult(ErrorHandleResult.Handled);
-            }, (id, ex, token) => { });
+            }, (_, _, _) => { });
 
             var messageId = Guid.NewGuid().ToString();
 
@@ -49,6 +50,31 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
         }
 
         [Test]
+        public async Task Should_rethrow_on_next_receive_when_message_could_not_be_completed()
+        {
+            var fakeQueueClient = new FakeQueueClient();
+
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((_, _) => Task.CompletedTask, (_, _) => Task.FromResult(ErrorHandleResult.Handled), (_, _, _) => { });
+
+            var messageId = Guid.NewGuid().ToString();
+
+            var rawMessageThatIsExpired = QueuesModelFactory.QueueMessage("RawMessageId1", "PopReceipt1", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)));
+            var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue");
+
+            fakeQueueClient.DeleteMessageCallback = () => throw new RequestFailedException(404, "MessageNotFound", QueueErrorCode.MessageNotFound.ToString(), null);
+
+            var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper2 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved2, messageWrapper2, "queue"));
+            Assert.That(fakeQueueClient.DeletedMessages, Is.Empty);
+        }
+
+        [Test]
         public async Task Should_complete_message_on_next_receive_when_error_pipeline_successful_but_completion_failed_due_to_expired_lease()
         {
             var fakeQueueClient = new FakeQueueClient();
@@ -56,15 +82,15 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
             var onMessageCalled = 0;
             var onErrorCalled = 0;
 
-            var receiveStrategy = new AtLeastOnceReceiveStrategy((context, token) =>
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((_, _) =>
             {
                 onMessageCalled++;
                 return Task.FromException<InvalidOperationException>(new InvalidOperationException());
-            }, (context, token) =>
+            }, (_, _) =>
             {
                 onErrorCalled++;
                 return Task.FromResult(ErrorHandleResult.Handled);
-            }, (id, ex, token) => { });
+            }, (_, _, _) => { });
 
             var messageId = Guid.NewGuid().ToString();
 

--- a/src/Tests/AtLeastOnceReceiveStrategyTests.cs
+++ b/src/Tests/AtLeastOnceReceiveStrategyTests.cs
@@ -33,7 +33,7 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
             var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
             var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = [] };
 
-            await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue");
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue"));
 
             var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
             var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
@@ -50,7 +50,7 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
         }
 
         [Test]
-        public async Task Should_rethrow_on_next_receive_when_message_could_not_be_completed()
+        public void Should_rethrow_on_next_receive_when_message_could_not_be_completed()
         {
             var fakeQueueClient = new FakeQueueClient();
 
@@ -62,7 +62,7 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
             var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
             var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = [] };
 
-            await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue");
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue"));
 
             fakeQueueClient.DeleteMessageCallback = () => throw new RequestFailedException(404, "MessageNotFound", QueueErrorCode.MessageNotFound.ToString(), null);
 
@@ -87,7 +87,7 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
             var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
             var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = [] };
 
-            await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue");
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue"));
 
             fakeQueueClient.DeleteMessageCallback = () => throw new RequestFailedException(404, "MessageNotFound", QueueErrorCode.MessageNotFound.ToString(), null);
 

--- a/src/Tests/AtLeastOnceReceiveStrategyTests.cs
+++ b/src/Tests/AtLeastOnceReceiveStrategyTests.cs
@@ -1,0 +1,91 @@
+namespace NServiceBus.Transport.AzureStorageQueues.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Azure.Transports.WindowsAzureStorageQueues;
+    using global::Azure.Storage.Queues.Models;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AtLeastOnceReceiveStrategyTests
+    {
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_pipeline_successful_but_completion_failed_due_to_expired_lease()
+        {
+            var fakeQueueClient = new FakeQueueClient();
+            var onMessageCalled = 0;
+            var onErrorCalled = 0;
+
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((context, token) =>
+            {
+                onMessageCalled++;
+                return Task.CompletedTask;
+            }, (context, token) =>
+            {
+                onErrorCalled++;
+                return Task.FromResult(ErrorHandleResult.Handled);
+            }, (id, ex, token) => { });
+
+            var messageId = Guid.NewGuid().ToString();
+
+            var rawMessageThatIsExpired = QueuesModelFactory.QueueMessage("RawMessageId1", "PopReceipt1", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)));
+            var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue");
+
+            var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper2 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            await receiveStrategy.Receive(messageRetrieved2, messageWrapper2, "queue");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fakeQueueClient.DeletedMessages, Has.Count.EqualTo(1).And.Contains(("RawMessageId2", "PopReceipt2")));
+                Assert.That(onMessageCalled, Is.EqualTo(1));
+                Assert.That(onErrorCalled, Is.Zero);
+            });
+        }
+
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_error_pipeline_successful_but_completion_failed_due_to_expired_lease()
+        {
+            var fakeQueueClient = new FakeQueueClient();
+
+            var onMessageCalled = 0;
+            var onErrorCalled = 0;
+
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((context, token) =>
+            {
+                onMessageCalled++;
+                return Task.FromException<InvalidOperationException>(new InvalidOperationException());
+            }, (context, token) =>
+            {
+                onErrorCalled++;
+                return Task.FromResult(ErrorHandleResult.Handled);
+            }, (id, ex, token) => { });
+
+            var messageId = Guid.NewGuid().ToString();
+
+            var rawMessageThatIsExpired = QueuesModelFactory.QueueMessage("RawMessageId1", "PopReceipt1", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)));
+            var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue");
+
+            var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper2 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            await receiveStrategy.Receive(messageRetrieved2, messageWrapper2, "queue");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fakeQueueClient.DeletedMessages, Has.Count.EqualTo(1).And.Contains(("RawMessageId2", "PopReceipt2")));
+                Assert.That(onMessageCalled, Is.EqualTo(1));
+                Assert.That(onErrorCalled, Is.EqualTo(1));
+            });
+        }
+    }
+}

--- a/src/Tests/AtLeastOnceReceiveStrategyTests.cs
+++ b/src/Tests/AtLeastOnceReceiveStrategyTests.cs
@@ -75,6 +75,40 @@ namespace NServiceBus.Transport.AzureStorageQueues.Tests
         }
 
         [Test]
+        public async Task Should_eventually_complete_the_message_even_when_next_receive_threw_when_message_could_not_be_completed()
+        {
+            var fakeQueueClient = new FakeQueueClient();
+
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((_, _) => Task.CompletedTask, (_, _) => Task.FromResult(ErrorHandleResult.Handled), (_, _, _) => { });
+
+            var messageId = Guid.NewGuid().ToString();
+
+            var rawMessageThatIsExpired = QueuesModelFactory.QueueMessage("RawMessageId1", "PopReceipt1", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)));
+            var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue");
+
+            fakeQueueClient.DeleteMessageCallback = () => throw new RequestFailedException(404, "MessageNotFound", QueueErrorCode.MessageNotFound.ToString(), null);
+
+            var rawMessageThatCannotBeCompleted = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatCannotBeCompleted, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper2 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved2, messageWrapper2, "queue"));
+
+            fakeQueueClient.DeleteMessageCallback = () => Task.FromResult(default(Response));
+
+            var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId3", "PopReceipt3", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved3 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null, DateTimeOffset.UtcNow, TimeProvider.System);
+            var messageWrapper3 = new MessageWrapper { Id = messageId, Headers = [] };
+
+            await receiveStrategy.Receive(messageRetrieved3, messageWrapper3, "queue");
+
+            Assert.That(fakeQueueClient.DeletedMessages, Has.Count.EqualTo(1).And.Contains(("RawMessageId3", "PopReceipt3")));
+        }
+
+        [Test]
         public async Task Should_complete_message_on_next_receive_when_error_pipeline_successful_but_completion_failed_due_to_expired_lease()
         {
             var fakeQueueClient = new FakeQueueClient();

--- a/src/Tests/FakeQueueClient.cs
+++ b/src/Tests/FakeQueueClient.cs
@@ -11,11 +11,14 @@ public class FakeQueueClient() : QueueClient(new Uri("http://localhost"))
 {
     public IReadOnlyCollection<(string messageId, string popReceipt)> DeletedMessages => deletedMessages;
 
-    public override Task<Response> DeleteMessageAsync(string messageId, string popReceipt,
-        CancellationToken cancellationToken = new CancellationToken())
+    public Func<Task<Response>> DeleteMessageCallback = () => Task.FromResult(default(Response));
+
+    public override async Task<Response> DeleteMessageAsync(string messageId, string popReceipt,
+        CancellationToken cancellationToken = default)
     {
+        var response = await DeleteMessageCallback();
         deletedMessages.Add((messageId, popReceipt));
-        return Task.FromResult(default(Response));
+        return response;
     }
 
     readonly List<(string messageId, string popReceipt)> deletedMessages = [];

--- a/src/Tests/FakeQueueClient.cs
+++ b/src/Tests/FakeQueueClient.cs
@@ -1,0 +1,22 @@
+namespace NServiceBus.Transport.AzureStorageQueues.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using global::Azure;
+using global::Azure.Storage.Queues;
+
+public class FakeQueueClient() : QueueClient(new Uri("http://localhost"))
+{
+    public IReadOnlyCollection<(string messageId, string popReceipt)> DeletedMessages => deletedMessages;
+
+    public override Task<Response> DeleteMessageAsync(string messageId, string popReceipt,
+        CancellationToken cancellationToken = new CancellationToken())
+    {
+        deletedMessages.Add((messageId, popReceipt));
+        return Task.FromResult(default(Response));
+    }
+
+    readonly List<(string messageId, string popReceipt)> deletedMessages = [];
+}

--- a/src/Tests/NServiceBus.Transport.AzureStorageQueues.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureStorageQueues.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NServiceBus" Version="9.2.2" />

--- a/src/Tests/NServiceBus.Transport.AzureStorageQueues.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureStorageQueues.Tests.csproj
@@ -12,17 +12,21 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="NServiceBus" Version="9.2.2" />
+    <PackageReference Include="Particular.Approvals" Version="1.0.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NServiceBus" Version="9.2.2" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Particular.Approvals" Version="1.0.0" />
-    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
             {
                 try
                 {
-                    Logger.DebugFormat("Received message (ID: '{0}') was marked as successfully completed. Trying to immediately acknowledge the message.", message.Id);
+                    Logger.DebugFormat("Received message (ID: '{0}') was marked as successfully completed. Trying to immediately acknowledge the message without invoking the pipeline.", message.Id);
                     await retrieved.Ack(cancellationToken).ConfigureAwait(false);
                 }
                 // Doing a more generous catch here to make sure we are not losing the ID and can mark it to be completed another time

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -32,7 +32,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
             }
 
             Logger.DebugFormat("Pushing received message (ID: '{0}') through pipeline.", message.Id);
-            var body = message.Body ?? Array.Empty<byte>();
+            var body = message.Body ?? [];
             var contextBag = new ContextBag();
             try
             {

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
             }
             catch (LeaseTimeoutException)
             {
-                messagesToBeAcked.AddOrUpdate(message.Id, true);
+                TrackMessageToBeCompletedOnNextReceive();
             }
             catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
@@ -69,7 +69,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
                         }
                         catch (LeaseTimeoutException)
                         {
-                            messagesToBeAcked.AddOrUpdate(message.Id, true);
+                            TrackMessageToBeCompletedOnNextReceive();
                         }
                     }
                 }
@@ -93,6 +93,12 @@ namespace NServiceBus.Transport.AzureStorageQueues
                     }
                 }
             }
+
+            return;
+
+            void TrackMessageToBeCompletedOnNextReceive() =>
+                // The raw message ID might not be stable across retries, so we use the message wrapper ID instead.
+                messagesToBeAcked.AddOrUpdate(message.Id, true);
         }
 
         readonly OnMessage onMessage;

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -88,7 +88,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
                 }
                 catch (RequestFailedException e) when (e.Status == 413 && e.ErrorCode == "RequestBodyTooLarge")
                 {
-                    Logger.WarnFormat($"Message with native ID `{message.Id}` could not be moved to the error queue with additional headers because it was too large. Moving to the error queue as is.", e);
+                    Logger.Warn($"Message with native ID `{message.Id}` could not be moved to the error queue with additional headers because it was too large. Moving to the error queue as is.", e);
 
                     await retrieved.MoveToErrorQueueWithMinimalFaultHeaders(context, cancellationToken).ConfigureAwait(false);
                 }

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -8,6 +8,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
     using BitFaster.Caching.Lru;
     using Extensibility;
     using global::Azure;
+    using global::Azure.Storage.Queues.Models;
     using Logging;
     using Transport;
 
@@ -44,6 +45,8 @@ namespace NServiceBus.Transport.AzureStorageQueues
             Logger.DebugFormat("Pushing received message (ID: '{0}') through pipeline.", message.Id);
             var body = message.Body ?? [];
             var contextBag = new ContextBag();
+            contextBag.Set<QueueMessage>(retrieved);
+
             try
             {
                 var pushContext = new MessageContext(message.Id, new Dictionary<string, string>(message.Headers), body, new TransportTransaction(), receiveAddress, contextBag);

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -92,9 +92,9 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
                     await retrieved.MoveToErrorQueueWithMinimalFaultHeaders(context, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception onErrorEx) when (!onErrorEx.IsCausedBy(cancellationToken))
+                catch (Exception e) when (!e.IsCausedBy(cancellationToken))
                 {
-                    criticalErrorAction($"Failed to execute recoverability policy for message with native ID: `{message.Id}`", onErrorEx, cancellationToken);
+                    criticalErrorAction($"Failed to execute recoverability policy for message with native ID: `{message.Id}`", e, cancellationToken);
 
                     try
                     {

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -57,6 +57,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
             catch (LeaseTimeoutException)
             {
                 TrackMessageToBeCompletedOnNextReceive();
+                throw;
             }
             catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
@@ -83,6 +84,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
                         catch (LeaseTimeoutException)
                         {
                             TrackMessageToBeCompletedOnNextReceive();
+                            throw;
                         }
                     }
                 }

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -70,7 +70,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
                     {
                         // For an immediate retry, the error is logged and the message is returned to the queue to preserve the DequeueCount.
                         // There is no in memory retry as scale-out scenarios would be handled improperly.
-                        Logger.Warn("Azure Storage Queue transport failed pushing a message through pipeline. The message will be requeued", ex);
+                        Logger.Debug("Azure Storage Queue transport failed pushing a message through pipeline. The message will be requeued", ex);
                         await retrieved.Nack(cancellationToken).ConfigureAwait(false);
                     }
                     else

--- a/src/Transport/AtMostOnceReceiveStrategy.cs
+++ b/src/Transport/AtMostOnceReceiveStrategy.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
     using Azure.Transports.WindowsAzureStorageQueues;
     using Extensibility;
     using global::Azure;
+    using global::Azure.Storage.Queues.Models;
     using Logging;
     using Transport;
 
@@ -28,8 +29,10 @@ namespace NServiceBus.Transport.AzureStorageQueues
         {
             Logger.DebugFormat("Pushing received message (ID: '{0}') through pipeline.", message.Id);
             await retrieved.Ack(cancellationToken).ConfigureAwait(false);
-            var body = message.Body ?? Array.Empty<byte>();
+            var body = message.Body ?? [];
             var contextBag = new ContextBag();
+            contextBag.Set<QueueMessage>(retrieved);
+
             try
             {
                 var pushContext = new MessageContext(message.Id, new Dictionary<string, string>(message.Headers), body, new TransportTransaction(), receiveAddress, contextBag);

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -146,6 +146,8 @@
             }
         }
 
+        public static implicit operator QueueMessage(MessageRetrieved messageRetrieved) => messageRetrieved.rawMessage;
+
         BinaryData ReWrap(MessageWrapper wrapper)
         {
             string base64String = MessageWrapperHelper.ConvertToBase64String(wrapper, serializer);

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -164,10 +164,6 @@
         static ILog Logger = LogManager.GetLogger<MessageRetrieved>();
     }
 
-    class LeaseTimeoutException : Exception
-    {
-        public LeaseTimeoutException(QueueMessage rawMessage, TimeSpan visibilityTimeoutExceededBy) : base($"The pop receipt of the cloud queue message '{rawMessage.MessageId}' is invalid as it exceeded the next visible time by '{visibilityTimeoutExceededBy}'.")
-        {
-        }
-    }
+    sealed class LeaseTimeoutException(QueueMessage rawMessage, TimeSpan visibilityTimeoutExceededBy)
+        : Exception($"The pop receipt of the cloud queue message '{rawMessage.MessageId}' is invalid as it exceeded the next visible time by '{visibilityTimeoutExceededBy}'.");
 }

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -59,6 +59,8 @@
             {
                 await inputQueue.DeleteMessageAsync(rawMessage.MessageId, rawMessage.PopReceipt, cancellationToken).ConfigureAwait(false);
             }
+            // AssertVisibilityTimeout might suffer from clock drifts, so we need to handle the case when the message is not found
+            // which might indicate the message visibility timeout has expired.
             catch (RequestFailedException ex) when (ex.ErrorCode == QueueErrorCode.MessageNotFound)
             {
                 throw new LeaseTimeoutException(rawMessage, visibilityTimeoutExceededBy: TimeSpan.Zero);

--- a/src/Transport/NServiceBus.Transport.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureStorageQueues.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="[12.19.1, 13.0.0)" />
     <PackageReference Include="Azure.Storage.Queues" Version="[12.17.1, 13.0.0)" />
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
+    <PackageReference Include="BitFaster.Caching" Version="[2.5.1, 3.0.0)" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" />

--- a/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
@@ -9,15 +9,18 @@
   <ItemGroup>
     <ProjectReference Include="..\Transport\NServiceBus.Transport.AzureStorageQueues.csproj" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="9.2.2" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />


### PR DESCRIPTION
This PR follows through on related changes done in [Amazon SQS](https://github.com/Particular/NServiceBus.AmazonSQS/pull/1861) but adjusts the core pieces of the change to Azure Storage Queue-specific behavior. Additionally, it brings in a number of layered tests that verify the code works as expected and doesn't accidentally break later.

And LRU cache to track the delivery attempts is not necessary because the receive count is automatically updated by the storage queue infrastructure.

The logic in `AtLeastOnceReceiveStrategy` has been updated significantly:

- Caching Acknowledged Messages: A cache (using `BitFaster.Caching.Lru`) is introduced to keep track of messages that have been marked as successfully completed. This helps in avoiding unnecessary retries for messages that are already acknowledged.
- Lease Timeout Handling: The code now explicitly handles cases where a message's lease expires (via the existing `LeaseTimeoutException`). This is handled both when acknowledging a message (via `Ack()`) and during error recovery. If a lease timeout occurs, the message is tracked for completion in the next receive attempt.
- Error Handling Improvements: Enhanced handling around retries and error recovery, including better logging and recovery actions for different failure scenarios.
- Pipeline Changes: The handling pipeline now passes the raw Azure Queue messages (`QueueMessage`) through the context bag for further processing.

## Before

```mermaid
graph TD
    A[Receive Message] --> B[Invoke OnMessage]
    B --> C{Success?}
    C -- Yes --> D[Acknowledge message]
    D --> E[Message acknowledged]  
    C -- No --> F[Invoke OnError]
    F --> G{Error requires retry?}
    G -- Yes --> H[Requeue message]
    G -- No --> I[Acknowledge message]
    H --> J[Message requeued]
    I --> E[Message acknowledged]
```

## After

```mermaid
graph TD
    A[Receive Message] --> B[ID in LRU]
    B -- Yes --> M[Acknowledge message]
    F --> G[Message tracked]
    B -- No --> H[Invoke OnMessage]
    H --> I{Success?}
    I -- Yes --> M
    I -- No --> J[Invoke OnError]
    J --> K{Error requires retry?}
    K -- Yes --> L[Requeue message]
    K -- No --> M[Acknowledge message]
    M --> N{Ack success?}
    N -- Yes --> E[Message acknowledged]
    N -- No --> F[Track ID in LRU]
    G -- Message requeued --> A
```

## Tradeoffs

The tradeoffs are the sames as the other fixes applied in RabbitMQ and Amazon SQS. In competing consumer scenarios there can still be more retries because the LRU cache is in memory, but it is still marginally better than having a potentially unlimited number of retries. 

As for the transaction mode `None`, there is no change required since we are not giving any guarantees there and messages are acknowledged early on.