### PR TITLE
Endpoint shuts down and triggers critical error while acknowledging   a message that has failed and exceeded the visibility timeout

### DIFF
--- a/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.csproj
@@ -12,15 +12,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <PackageReference Include="Azure.Data.Tables" Version="12.7.1" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.2" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AcceptanceTests/Receiving/When_message_visibility_expired.cs
+++ b/src/AcceptanceTests/Receiving/When_message_visibility_expired.cs
@@ -1,0 +1,119 @@
+﻿namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using global::Azure.Storage.Queues;
+    using global::Azure.Storage.Queues.Models;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Testing;
+
+    public class When_message_visibility_expired : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_pipeline_successful()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<Receiver>(b =>
+                {
+                    b.CustomConfig(c =>
+                    {
+                        // Limiting the concurrency for this test to make sure messages that are made available again are 
+                        // not concurrently processed. This is not necessary for the test to pass but it makes
+                        // reasoning about the test easier.
+                        c.LimitMessageProcessingConcurrencyTo(1);
+                    });
+                    b.When((session, _) => session.SendLocal(new MyMessage()));
+                })
+                .Done(c => c.MessageId is not null && c.Logs.Any(l => WasMarkedAsSuccessfullyCompleted(l, c)))
+                .Run();
+
+            var items = ctx.Logs.Where(l => WasMarkedAsSuccessfullyCompleted(l, ctx)).ToArray();
+
+            Assert.That(items, Is.Not.Empty);
+        }
+
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_error_pipeline_handled_the_message()
+        {
+            var ctx = await Scenario.Define<Context>(c =>
+                {
+                    c.ShouldThrow = true;
+                })
+                .WithEndpoint<Receiver>(b =>
+                {
+                    b.DoNotFailOnErrorMessages();
+                    b.CustomConfig(c =>
+                    {
+                        var recoverability = c.Recoverability();
+                        recoverability.AddUnrecoverableException<InvalidOperationException>();
+
+                        // Limiting the concurrency for this test to make sure messages that are made available again are 
+                        // not concurrently processed. This is not necessary for the test to pass but it makes
+                        // reasoning about the test easier.
+                        c.LimitMessageProcessingConcurrencyTo(1);
+                    });
+                    b.When((session, _) => session.SendLocal(new MyMessage()));
+                })
+                .Done(c => c.MessageId is not null && c.Logs.Any(l => WasMarkedAsSuccessfullyCompleted(l, c)))
+                .Run();
+
+            var items = ctx.Logs.Where(l => WasMarkedAsSuccessfullyCompleted(l, ctx)).ToArray();
+
+            Assert.That(items, Is.Not.Empty);
+        }
+
+        static bool WasMarkedAsSuccessfullyCompleted(ScenarioContext.LogItem l, Context c)
+            => l.Message.StartsWith($"Received message (ID: '{c.MessageId}') was marked as successfully completed");
+
+        class Context : ScenarioContext
+        {
+            public bool ShouldThrow { get; set; }
+
+            public string MessageId { get; set; }
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver() => EndpointSetup<DefaultServer>(c =>
+            {
+                var transport = c.ConfigureTransport<AzureStorageQueueTransport>();
+                // Explicitly setting the transport transaction mode to ReceiveOnly because the message 
+                // tracking only is implemented for this mode.
+                transport.TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
+            });
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+
+        class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            readonly Context testContext;
+
+            public MyMessageHandler(Context testContext) => this.testContext = testContext;
+
+            public async Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                var receiverQueue = BackwardsCompatibleQueueNameSanitizerForTests.Sanitize(Conventions.EndpointNamingConvention(typeof(Receiver)));
+                var queueClient = new QueueClient(Utilities.GetEnvConfiguredConnectionString(), receiverQueue);
+                var rawMessage = context.Extensions.Get<QueueMessage>();
+                // By setting the visibility timeout zero, the message will be "immediately available" for retrieval again and effectively the message pump
+                // has lost the message visibility timeout because any ACK or NACK will be rejected by the storage service.
+                await queueClient.UpdateMessageAsync(rawMessage.MessageId, rawMessage.PopReceipt, visibilityTimeout: TimeSpan.Zero, cancellationToken: context.CancellationToken);
+
+                testContext.MessageId = context.MessageId;
+
+                if (testContext.ShouldThrow)
+                {
+                    throw new InvalidOperationException("Simulated exception");
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/AtLeastOnceReceiveStrategyTests.cs
+++ b/src/Tests/AtLeastOnceReceiveStrategyTests.cs
@@ -1,0 +1,152 @@
+namespace NServiceBus.Transport.AzureStorageQueues.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Azure.Transports.WindowsAzureStorageQueues;
+    using global::Azure;
+    using global::Azure.Storage.Queues.Models;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AtLeastOnceReceiveStrategyTests
+    {
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_pipeline_successful_but_completion_failed_due_to_expired_lease()
+        {
+            var fakeQueueClient = new FakeQueueClient();
+            var onMessageCalled = 0;
+            var onErrorCalled = 0;
+
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((_, _) =>
+            {
+                onMessageCalled++;
+                return Task.CompletedTask;
+            }, (_, _) =>
+            {
+                onErrorCalled++;
+                return Task.FromResult(ErrorHandleResult.Handled);
+            }, (_, _, _) => { });
+
+            var messageId = Guid.NewGuid().ToString();
+
+            var rawMessageThatIsExpired = QueuesModelFactory.QueueMessage("RawMessageId1", "PopReceipt1", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)));
+            var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null);
+            var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue"));
+
+            var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null);
+            var messageWrapper2 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            await receiveStrategy.Receive(messageRetrieved2, messageWrapper2, "queue");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fakeQueueClient.DeletedMessages, Has.Count.EqualTo(1).And.Contains(("RawMessageId2", "PopReceipt2")));
+                Assert.That(onMessageCalled, Is.EqualTo(1));
+                Assert.That(onErrorCalled, Is.Zero);
+            });
+        }
+
+        [Test]
+        public void Should_rethrow_on_next_receive_when_message_could_not_be_completed()
+        {
+            var fakeQueueClient = new FakeQueueClient();
+
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((_, _) => Task.CompletedTask, (_, _) => Task.FromResult(ErrorHandleResult.Handled), (_, _, _) => { });
+
+            var messageId = Guid.NewGuid().ToString();
+
+            var rawMessageThatIsExpired = QueuesModelFactory.QueueMessage("RawMessageId1", "PopReceipt1", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)));
+            var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null);
+            var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue"));
+
+            fakeQueueClient.DeleteMessageCallback = () => throw new RequestFailedException(404, "MessageNotFound", QueueErrorCode.MessageNotFound.ToString(), null);
+
+            var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null);
+            var messageWrapper2 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved2, messageWrapper2, "queue"));
+            Assert.That(fakeQueueClient.DeletedMessages, Is.Empty);
+        }
+
+        [Test]
+        public async Task Should_eventually_complete_the_message_even_when_next_receive_threw_when_message_could_not_be_completed()
+        {
+            var fakeQueueClient = new FakeQueueClient();
+
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((_, _) => Task.CompletedTask, (_, _) => Task.FromResult(ErrorHandleResult.Handled), (_, _, _) => { });
+
+            var messageId = Guid.NewGuid().ToString();
+
+            var rawMessageThatIsExpired = QueuesModelFactory.QueueMessage("RawMessageId1", "PopReceipt1", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)));
+            var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null);
+            var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue"));
+
+            fakeQueueClient.DeleteMessageCallback = () => throw new RequestFailedException(404, "MessageNotFound", QueueErrorCode.MessageNotFound.ToString(), null);
+
+            var rawMessageThatCannotBeCompleted = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatCannotBeCompleted, fakeQueueClient, null);
+            var messageWrapper2 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            Assert.ThrowsAsync<LeaseTimeoutException>(async () => await receiveStrategy.Receive(messageRetrieved2, messageWrapper2, "queue"));
+
+            fakeQueueClient.DeleteMessageCallback = () => Task.FromResult(default(Response));
+
+            var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId3", "PopReceipt3", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved3 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null);
+            var messageWrapper3 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            await receiveStrategy.Receive(messageRetrieved3, messageWrapper3, "queue");
+
+            Assert.That(fakeQueueClient.DeletedMessages, Has.Count.EqualTo(1).And.Contains(("RawMessageId3", "PopReceipt3")));
+        }
+
+        [Test]
+        public async Task Should_complete_message_on_next_receive_when_error_pipeline_successful_but_completion_failed_due_to_expired_lease()
+        {
+            var fakeQueueClient = new FakeQueueClient();
+
+            var onMessageCalled = 0;
+            var onErrorCalled = 0;
+
+            var receiveStrategy = new AtLeastOnceReceiveStrategy((_, _) =>
+            {
+                onMessageCalled++;
+                return Task.FromException<InvalidOperationException>(new InvalidOperationException());
+            }, (_, _) =>
+            {
+                onErrorCalled++;
+                return Task.FromResult(ErrorHandleResult.Handled);
+            }, (_, _, _) => { });
+
+            var messageId = Guid.NewGuid().ToString();
+
+            var rawMessageThatIsExpired = QueuesModelFactory.QueueMessage("RawMessageId1", "PopReceipt1", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(30)));
+            var messageRetrieved1 = new MessageRetrieved(null, null, rawMessageThatIsExpired, fakeQueueClient, null);
+            var messageWrapper1 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            await receiveStrategy.Receive(messageRetrieved1, messageWrapper1, "queue");
+
+            var rawMessageThatIsValid = QueuesModelFactory.QueueMessage("RawMessageId2", "PopReceipt2", "", 1, nextVisibleOn: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(30)));
+            var messageRetrieved2 = new MessageRetrieved(null, null, rawMessageThatIsValid, fakeQueueClient, null);
+            var messageWrapper2 = new MessageWrapper { Id = messageId, Headers = new Dictionary<string, string>() };
+
+            await receiveStrategy.Receive(messageRetrieved2, messageWrapper2, "queue");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fakeQueueClient.DeletedMessages, Has.Count.EqualTo(1).And.Contains(("RawMessageId2", "PopReceipt2")));
+                Assert.That(onMessageCalled, Is.EqualTo(1));
+                Assert.That(onErrorCalled, Is.EqualTo(1));
+            });
+        }
+    }
+}

--- a/src/Tests/FakeQueueClient.cs
+++ b/src/Tests/FakeQueueClient.cs
@@ -1,0 +1,30 @@
+namespace NServiceBus.Transport.AzureStorageQueues.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using global::Azure;
+    using global::Azure.Storage.Queues;
+
+    public class FakeQueueClient : QueueClient
+    {
+        public FakeQueueClient() : base(new Uri("http://localhost"))
+        {
+        }
+
+        public IReadOnlyCollection<(string messageId, string popReceipt)> DeletedMessages => deletedMessages;
+
+        public Func<Task<Response>> DeleteMessageCallback = () => Task.FromResult(default(Response));
+
+        public override async Task<Response> DeleteMessageAsync(string messageId, string popReceipt,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await DeleteMessageCallback();
+            deletedMessages.Add((messageId, popReceipt));
+            return response;
+        }
+
+        readonly List<(string messageId, string popReceipt)> deletedMessages = new List<(string messageId, string popReceipt)>();
+    }
+}

--- a/src/Tests/NServiceBus.Transport.AzureStorageQueues.Tests.csproj
+++ b/src/Tests/NServiceBus.Transport.AzureStorageQueues.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net481;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBusTests.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,16 +12,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
-    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.2" />
     <PackageReference Include="NServiceBus" Version="8.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Particular.Approvals" Version="1.0.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Transport/AtLeastOnceReceiveStrategy.cs
+++ b/src/Transport/AtLeastOnceReceiveStrategy.cs
@@ -5,8 +5,10 @@ namespace NServiceBus.Transport.AzureStorageQueues
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Transports.WindowsAzureStorageQueues;
+    using BitFaster.Caching.Lru;
     using Extensibility;
     using global::Azure;
+    using global::Azure.Storage.Queues.Models;
     using Logging;
     using Transport;
 
@@ -24,9 +26,27 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
         public override async Task Receive(MessageRetrieved retrieved, MessageWrapper message, string receiveAddress, CancellationToken cancellationToken = default)
         {
+            if (messagesToBeAcked.TryGet(message.Id, out _))
+            {
+                try
+                {
+                    Logger.DebugFormat("Received message (ID: '{0}') was marked as successfully completed. Trying to immediately acknowledge the message without invoking the pipeline.", message.Id);
+                    await retrieved.Ack(cancellationToken).ConfigureAwait(false);
+                }
+                // Doing a more generous catch here to make sure we are not losing the ID and can mark it to be completed another time
+                catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
+                {
+                    TrackMessageToBeCompletedOnNextReceive();
+                    throw;
+                }
+                return;
+            }
+
             Logger.DebugFormat("Pushing received message (ID: '{0}') through pipeline.", message.Id);
             var body = message.Body ?? Array.Empty<byte>();
             var contextBag = new ContextBag();
+            contextBag.Set<QueueMessage>(retrieved);
+
             try
             {
                 var pushContext = new MessageContext(message.Id, new Dictionary<string, string>(message.Headers), body, new TransportTransaction(), receiveAddress, contextBag);
@@ -36,8 +56,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
             }
             catch (LeaseTimeoutException)
             {
-                // The lease has expired and cannot be used any longer to Ack or Nack the message.
-                // see original issue: https://github.com/Azure/azure-storage-net/issues/285
+                TrackMessageToBeCompletedOnNextReceive();
                 throw;
             }
             catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
@@ -52,24 +71,32 @@ namespace NServiceBus.Transport.AzureStorageQueues
                     {
                         // For an immediate retry, the error is logged and the message is returned to the queue to preserve the DequeueCount.
                         // There is no in memory retry as scale-out scenarios would be handled improperly.
-                        Logger.Warn("Azure Storage Queue transport failed pushing a message through pipeline. The message will be requeued", ex);
+                        Logger.Debug("Azure Storage Queue transport failed pushing a message through pipeline. The message will be requeued", ex);
                         await retrieved.Nack(cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
-                        // Just acknowledge the message as it's handled by the core retry.
-                        await retrieved.Ack(cancellationToken).ConfigureAwait(false);
+                        try
+                        {
+                            // Just acknowledge the message as it's handled by the core retry.
+                            await retrieved.Ack(cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (LeaseTimeoutException)
+                        {
+                            TrackMessageToBeCompletedOnNextReceive();
+                            throw;
+                        }
                     }
                 }
                 catch (RequestFailedException e) when (e.Status == 413 && e.ErrorCode == "RequestBodyTooLarge")
                 {
-                    Logger.WarnFormat($"Message with native ID `{message.Id}` could not be moved to the error queue with additional headers because it was too large. Moving to the error queue as is.", e);
+                    Logger.Warn($"Message with native ID `{message.Id}` could not be moved to the error queue with additional headers because it was too large. Moving to the error queue as is.", e);
 
                     await retrieved.MoveToErrorQueueWithMinimalFaultHeaders(context, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception onErrorEx) when (!onErrorEx.IsCausedBy(cancellationToken))
+                catch (Exception e) when (!e.IsCausedBy(cancellationToken))
                 {
-                    criticalErrorAction($"Failed to execute recoverability policy for message with native ID: `{message.Id}`", onErrorEx, cancellationToken);
+                    criticalErrorAction($"Failed to execute recoverability policy for message with native ID: `{message.Id}`", e, cancellationToken);
 
                     try
                     {
@@ -81,11 +108,18 @@ namespace NServiceBus.Transport.AzureStorageQueues
                     }
                 }
             }
+
+            return;
+
+            void TrackMessageToBeCompletedOnNextReceive() =>
+                // The raw message ID might not be stable across retries, so we use the message wrapper ID instead.
+                messagesToBeAcked.AddOrUpdate(message.Id, true);
         }
 
         readonly OnMessage onMessage;
         readonly OnError onError;
         readonly Action<string, Exception, CancellationToken> criticalErrorAction;
+        readonly FastConcurrentLru<string, bool> messagesToBeAcked = new(1_000);
 
         static readonly ILog Logger = LogManager.GetLogger<ReceiveStrategy>();
     }

--- a/src/Transport/AtMostOnceReceiveStrategy.cs
+++ b/src/Transport/AtMostOnceReceiveStrategy.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Transport.AzureStorageQueues
     using Azure.Transports.WindowsAzureStorageQueues;
     using Extensibility;
     using global::Azure;
+    using global::Azure.Storage.Queues.Models;
     using Logging;
     using Transport;
 
@@ -30,6 +31,8 @@ namespace NServiceBus.Transport.AzureStorageQueues
             await retrieved.Ack(cancellationToken).ConfigureAwait(false);
             var body = message.Body ?? Array.Empty<byte>();
             var contextBag = new ContextBag();
+            contextBag.Set<QueueMessage>(retrieved);
+
             try
             {
                 var pushContext = new MessageContext(message.Id, new Dictionary<string, string>(message.Headers), body, new TransportTransaction(), receiveAddress, contextBag);

--- a/src/Transport/MessageRetrieved.cs
+++ b/src/Transport/MessageRetrieved.cs
@@ -49,11 +49,20 @@
         /// <summary>
         /// Acknowledges the successful processing of the message.
         /// </summary>
-        public Task Ack(CancellationToken cancellationToken = default)
+        public async Task Ack(CancellationToken cancellationToken = default)
         {
             AssertVisibilityTimeout();
 
-            return inputQueue.DeleteMessageAsync(rawMessage.MessageId, rawMessage.PopReceipt, cancellationToken);
+            try
+            {
+                await inputQueue.DeleteMessageAsync(rawMessage.MessageId, rawMessage.PopReceipt, cancellationToken).ConfigureAwait(false);
+            }
+            // AssertVisibilityTimeout might suffer from clock drifts, so we need to handle the case when the message is not found
+            // which might indicate the message visibility timeout has expired.
+            catch (RequestFailedException ex) when (ex.ErrorCode == QueueErrorCode.MessageNotFound)
+            {
+                throw new LeaseTimeoutException(rawMessage, visibilityTimeoutExceededBy: TimeSpan.Zero);
+            }
         }
 
         /// <summary>
@@ -132,6 +141,8 @@
             }
         }
 
+        public static implicit operator QueueMessage(MessageRetrieved messageRetrieved) => messageRetrieved.rawMessage;
+
         BinaryData ReWrap(MessageWrapper wrapper)
         {
             string base64String = MessageWrapperHelper.ConvertToBase64String(wrapper, serializer);
@@ -147,7 +158,7 @@
         static ILog Logger = LogManager.GetLogger<MessageRetrieved>();
     }
 
-    class LeaseTimeoutException : Exception
+    sealed class LeaseTimeoutException : Exception
     {
         public LeaseTimeoutException(QueueMessage rawMessage, TimeSpan visibilityTimeoutExceededBy) : base($"The pop receipt of the cloud queue message '{rawMessage.MessageId}' is invalid as it exceeded the next visible time by '{visibilityTimeoutExceededBy}'.")
         {

--- a/src/Transport/NServiceBus.Transport.AzureStorageQueues.csproj
+++ b/src/Transport/NServiceBus.Transport.AzureStorageQueues.csproj
@@ -18,10 +18,14 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="[12.13.1, 13.0.0)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Fody" Version="6.6.4" PrivateAssets="All" />
+    <PackageReference Include="BitFaster.Caching" Version="[2.5.2, 3.0.0)" />
+  </ItemGroup>   
+
+  <ItemGroup>
+    <PackageReference Include="Fody" Version="6.8.0" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="4.1.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
+++ b/src/TransportTests/NServiceBus.Transport.AzureStorageQueues.TransportTests.csproj
@@ -4,19 +4,26 @@
     <TargetFrameworks>net481;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBusTests.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Transport\NServiceBus.Transport.AzureStorageQueues.csproj" />
   </ItemGroup>
 
-    <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  <ItemGroup>
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="BitFaster.Caching" Version="2.5.2" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport of #1212 to `release-12`