### PR TITLE
Stop pumps on shutdown

### DIFF
--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -34,12 +34,12 @@
 
             if (address.Discriminator != null)
             {
-                queue.Append("-" + address.Discriminator);
+                queue.Append($"-{address.Discriminator}");
             }
 
             if (address.Qualifier != null)
             {
-                queue.Append("-" + address.Qualifier);
+                queue.Append($"-{address.Qualifier}");
             }
 
             return addressGenerator.GetQueueName(queue.ToString());

--- a/src/Transport/AzureStorageQueueInfrastructure.cs
+++ b/src/Transport/AzureStorageQueueInfrastructure.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.AzureStorageQueues
 {
     using System.Collections.ObjectModel;
+    using System.Linq;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -16,8 +17,13 @@
             this.nativeDelayedDeliveryProcessor = nativeDelayedDeliveryProcessor;
         }
 
-        public override Task Shutdown(CancellationToken cancellationToken = default)
-            => nativeDelayedDeliveryProcessor.Stop(cancellationToken);
+        public override async Task Shutdown(CancellationToken cancellationToken = default)
+        {
+            await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
+                .ConfigureAwait(false);
+            await nativeDelayedDeliveryProcessor.Stop(cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         public override string ToTransportAddress(Transport.QueueAddress address)
             => TranslateAddress(address, transport.QueueAddressGenerator);

--- a/src/Transport/MessageReceiver.cs
+++ b/src/Transport/MessageReceiver.cs
@@ -95,9 +95,9 @@ namespace NServiceBus.Transport.AzureStorageQueues
             }
 
             Logger.Debug($"Stopping MessageReceiver {Id}");
-            messagePumpCancellationTokenSource?.Cancel();
+            await messagePumpCancellationTokenSource.CancelAsync().ConfigureAwait(false);
 
-            using (cancellationToken.Register(() => messageProcessingCancellationTokenSource?.Cancel()))
+            await using (cancellationToken.Register(() => messageProcessingCancellationTokenSource?.Cancel()))
             {
                 await Task.WhenAll(messagePumpTasks).ConfigureAwait(false);
 
@@ -122,8 +122,9 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
             concurrencyLimiter.Dispose();
 
-            messageProcessingCancellationTokenSource?.Dispose();
-            messagePumpCancellationTokenSource?.Dispose();
+            messageProcessingCancellationTokenSource.Dispose();
+            messagePumpCancellationTokenSource.Dispose();
+            messagePumpCancellationTokenSource = null;
             messagePumpTasks = null;
         }
 

--- a/src/Transport/MessageReceiver.cs
+++ b/src/Transport/MessageReceiver.cs
@@ -88,6 +88,12 @@ namespace NServiceBus.Transport.AzureStorageQueues
 
         public async Task StopReceive(CancellationToken cancellationToken = default)
         {
+            if (messagePumpCancellationTokenSource == null)
+            {
+                // already stopped or never started
+                return;
+            }
+
             Logger.Debug($"Stopping MessageReceiver {Id}");
             messagePumpCancellationTokenSource?.Cancel();
 


### PR DESCRIPTION
This aligns the transport to stop the pumps on transport shutdown and at the same time makes sure the pumps stop method can be called multiple times. 

This is part of addressing some low-hanging fruit to align all transports for the transport seam usage scenarios to make sure pumps are stopped when the transport shuts down. 

I have tried to write a transport test for it to enforce it eventually for all transport but couldn't find a way to do that without introducing flags on the transport interface and using fancy techniques like default members which seams overkill