### PR TITLE
Mark message-driven pub/sub compatibility mode as obsolete

### DIFF
--- a/src/AcceptanceTests/PubSub/When_migrating_publisher_first.cs
+++ b/src/AcceptanceTests/PubSub/When_migrating_publisher_first.cs
@@ -56,7 +56,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
                      b.CustomConfig(c =>
                      {
                          c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
+                         // When message-driven compatibility mode is obsoleted with an error this test can be removed
                          c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                      });
                      b.When((session, ctx) => session.Publish(new MyEvent()));
                  })
@@ -88,7 +91,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
                      b.CustomConfig(c =>
                      {
                          c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
+                         // When message-driven compatibility mode is obsoleted with an error this test can be removed
                          c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                      });
                      b.When(c => c.SubscribedMessageDriven && c.SubscribedNative, (session, ctx) => session.Publish(new MyEvent()));
                  })
@@ -97,7 +103,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
                  {
                      b.CustomConfig(c =>
                      {
+#pragma warning disable CS0618 // Type or member is obsolete
+                         // When message-driven compatibility mode is obsoleted with an error this test can be removed
                          var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                          // not needed but left here to enforce duplicates
                          compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);

--- a/src/AcceptanceTests/PubSub/When_migrating_subscriber_first.cs
+++ b/src/AcceptanceTests/PubSub/When_migrating_subscriber_first.cs
@@ -64,7 +64,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
                  {
                      b.CustomConfig(c =>
                      {
+#pragma warning disable CS0618 // Type or member is obsolete
+                         // When message-driven compatibility mode is obsoleted with an error this test can be removed
                          var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                          compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                      });
                      b.When(async (session, ctx) =>
@@ -86,7 +89,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
                      b.CustomConfig(c =>
                      {
                          c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
+                         // When message-driven compatibility mode is obsoleted with an error this test can be removed
                          c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                      });
                      b.When(c => c.SubscribedMessageDriven && c.SubscribedNative, (session, ctx) => session.Publish(new MyEvent()));
                  })
@@ -95,7 +101,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests
                  {
                      b.CustomConfig(c =>
                      {
+#pragma warning disable CS0618 // Type or member is obsolete
+                         // When message-driven compatibility mode is obsoleted with an error this test can be removed
                          var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                          // not needed but left here to enforce duplicates
                          compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                      });

--- a/src/AcceptanceTests/PubSub/When_publisher_runs_in_compat_mode.cs
+++ b/src/AcceptanceTests/PubSub/When_publisher_runs_in_compat_mode.cs
@@ -39,7 +39,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.PubSub
             public MigratedPublisher() =>
                 EndpointSetup<DefaultPublisher>(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                     c.OnEndpointSubscribed<Context>((s, context) =>
                     {
                         if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber))))

--- a/src/AcceptanceTests/PubSub/When_publisher_runs_in_compat_mode_and_scaled_subscriber_only_one_migrated.cs
+++ b/src/AcceptanceTests/PubSub/When_publisher_runs_in_compat_mode_and_scaled_subscriber_only_one_migrated.cs
@@ -61,7 +61,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.PubSub
             public Publisher() =>
                 EndpointSetup<DefaultPublisher>(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     c.OnEndpointSubscribed<Context>((s, context) =>
                     {

--- a/src/AcceptanceTests/PubSub/When_subscriber_runs_in_compat_mode.cs
+++ b/src/AcceptanceTests/PubSub/When_subscriber_runs_in_compat_mode.cs
@@ -50,7 +50,10 @@ namespace NServiceBus.Transport.AzureStorageQueues.AcceptanceTests.PubSub
             public MigratedSubscriber() =>
                 EndpointSetup<DefaultServer>(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     var compatMode = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     compatMode.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                     c.DisableFeature<AutoSubscribe>();

--- a/src/Tests/ApprovalFiles/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.ApproveAzureStorageQueueTransport.approved.txt
@@ -46,6 +46,9 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> DegreeOfReceiveParallelism(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, int degreeOfReceiveParallelism) { }
         public static NServiceBus.DelayedDeliverySettings DelayedDelivery(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> DisableCaching(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config) { }
+        [System.Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Wi" +
+            "ll be treated as an error from version 15.0.0. Will be removed in version 16.0.0" +
+            ".", false)]
         public static NServiceBus.SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> MaximumWaitTimeWhenIdle(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, System.TimeSpan value) { }
         public static NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> MessageInvisibleTime(this NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> config, System.TimeSpan value) { }
@@ -68,6 +71,9 @@ namespace NServiceBus
     }
     public static class MessageDrivenPubSubCompatibilityModeConfiguration
     {
+        [System.Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Wi" +
+            "ll be treated as an error from version 15.0.0. Will be removed in version 16.0.0" +
+            ".", false)]
         public static NServiceBus.SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.RoutingSettings routingSettings) { }
     }
     public class NativeDelayedDeliverySettings

--- a/src/Transport/Config/AzureStorageTransportExtensions.cs
+++ b/src/Transport/Config/AzureStorageTransportExtensions.cs
@@ -283,9 +283,10 @@ namespace NServiceBus
         /// Enables compatibility with endpoints running on message-driven pub-sub
         /// </summary>
         /// <param name="transportExtensions">The transport to enable pub-sub compatibility on</param>
-        [PreObsolete("https://github.com/Particular/NServiceBus/issues/6471",
-           Message = "Native publish/subscribe is always enabled in version 11. All endpoints must be updated to use native publish/subscribe before updating to this version.",
-           Note = "As long as core supports message-driven publish/subscribe migration mode, then the transports must continue to support it too.")]
+        [Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Will be treated as an error from version 15.0.0. Will be removed in version 16.0.0.", false)]
+        [ObsoleteMetadata(Message = "Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub",
+            TreatAsErrorFromVersion = "15.0.0",
+            RemoveInVersion = "16.0.0")]
         public static SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this TransportExtensions<AzureStorageQueueTransport> transportExtensions)
         {
             var subscriptionMigrationModeSettings = transportExtensions.Routing().EnableMessageDrivenPubSubCompatibilityMode();

--- a/src/Transport/PubSub/MessageDrivenPubSubCompatibilityModeConfiguration.cs
+++ b/src/Transport/PubSub/MessageDrivenPubSubCompatibilityModeConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus
 {
+    using System;
     using Configuration.AdvancedExtensibility;
+    using Particular.Obsoletes;
 
     /// <summary>
     /// Configuration extensions for Message-Driven Pub-Sub compatibility mode
@@ -11,6 +13,10 @@
         ///     Enables compatibility with endpoints running on message-driven pub-sub
         /// </summary>
         /// <param name="routingSettings">The transport to enable pub-sub compatibility on</param>
+        [Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Will be treated as an error from version 15.0.0. Will be removed in version 16.0.0.", false)]
+        [ObsoleteMetadata(Message = "Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub",
+            TreatAsErrorFromVersion = "15.0.0",
+            RemoveInVersion = "16.0.0")]
         public static SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(
             this RoutingSettings routingSettings)
         {


### PR DESCRIPTION
All uses of `EnableMessageDrivenPubSubCompatibilityMode` need to be marked as obsolete with a warning starting in the next minor version.

This also adds the `#pragma warning disable/restore` directives for tests only.